### PR TITLE
CI: split into CI (PR+main) and manual-dispatch Release; fix Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,15 @@
-name: PR
+name: CI
 
-# Fires on pull_request only. Runs the unit + integration tiers across
-# supported Python versions. No publish/release jobs — those live in
-# release.yml and fire on tag push.
+# Fires on pull_request and on push to main. Runs the unit +
+# integration tiers across supported Python versions. No publish /
+# release jobs — release.yml is manually dispatched from the Actions
+# tab when a release is ready to cut.
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,53 @@
 name: Release
 
-# Fires on tag push only (N.N.N). Re-runs the full unit+integration
-# test matrix as a final gate, then publishes to TestPyPI → PyPI,
+# Manually triggered from the Actions tab. Creates the tag, runs a
+# final test matrix as a gate, then publishes to TestPyPI -> PyPI,
 # cuts a GitHub Release, and pushes the Docker image to GHCR.
+#
+# workflow_dispatch is restricted to repo collaborators with write
+# access by GitHub's default policy, so this is effectively owner-only.
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 0.8.2, must match N.N.N)'
+        required: true
+        type: string
 
 jobs:
+  tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.validate.outputs.version }}
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Validate version and create tag
+      id: validate
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ inputs.version }}"
+        if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "error: version must be N.N.N, got '$VERSION'" >&2
+          exit 1
+        fi
+        if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+          echo "error: tag '$VERSION' already exists" >&2
+          exit 1
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a "$VERSION" -m "v$VERSION"
+        git push origin "$VERSION"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
   test:
+    needs: tag
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -45,11 +83,12 @@ jobs:
         path: /tmp/aiomoqt-regression.*/
 
   publish-test:
-    needs: test
+    needs: [tag, test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -70,11 +109,12 @@ jobs:
         twine upload dist/*
 
   publish-prod:
-    needs: [test, publish-test]
+    needs: [tag, test, publish-test]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -95,26 +135,27 @@ jobs:
         twine upload dist/*
 
   github-release:
-    needs: [publish-prod]
+    needs: [tag, publish-prod]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        TAG="${GITHUB_REF#refs/tags/}"
-        gh release create "$TAG" \
-          --title "v$TAG" \
+        VERSION="${{ needs.tag.outputs.version }}"
+        gh release create "$VERSION" \
+          --title "v$VERSION" \
           --generate-notes \
           --verify-tag
 
   docker-publish:
-    needs: [publish-prod]
+    needs: [tag, publish-prod]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -122,6 +163,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
     - name: Log in to GHCR
       uses: docker/login-action@v3
@@ -131,8 +173,10 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push Docker image
       run: |
-        TAG="${GITHUB_REF#refs/tags/}"
+        VERSION="${{ needs.tag.outputs.version }}"
         IMAGE=ghcr.io/${{ github.repository }}
-        docker build -t "$IMAGE:$TAG" -t "$IMAGE:latest" .
-        docker push "$IMAGE:$TAG"
+        docker build \
+          --build-arg VERSION="$VERSION" \
+          -t "$IMAGE:$VERSION" -t "$IMAGE:latest" .
+        docker push "$IMAGE:$VERSION"
         docker push "$IMAGE:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# setuptools_scm needs a version when .git isn't present in the build
+# context (which .dockerignore deliberately excludes to keep the image
+# small). The release workflow passes the tag as --build-arg VERSION=x.y.z.
+ARG VERSION=0.0.0
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
 COPY . .
 
 RUN pip install --no-cache-dir .

--- a/README.md
+++ b/README.md
@@ -242,22 +242,42 @@ python -m aiomoqt.examples.server_example \
 
 ## Interop Test Results
 
-All 6 [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
-test cases pass against multiple relays on draft-14 and draft-16:
+Results against live public relays, as probed by
+`tests/release-regression-test.py --test-tier interop` in v0.8.1.
+Tests use the 6 [moq-interop-runner](https://github.com/englishm/moq-interop-runner)
+cases plus `relay-pub-sub` (3-subscriber multi-sub bench).
+Error codes are validated to spec-conformant values
+(e.g. `subscribe-error` requires `TRACK_DOES_NOT_EXIST`, not `INTERNAL_ERROR`).
 
-| Relay | Draft | Transport | Tests | Result |
-|-------|-------|-----------|-------|--------|
-| OpenMoQ moqx | draft-16 | Raw QUIC | 6/6 | PASS |
-| OpenMoQ moqx | draft-14 | Raw QUIC | 6/6 | PASS |
-| Meta moxygen | draft-16 | Raw QUIC | 6/6 | PASS |
-| Meta moxygen | draft-14 | Raw QUIC | 6/6 | PASS |
-| Cloudflare moq-rs | draft-14 | Raw QUIC | 6/6 | PASS |
-| Red5 Pro | draft-14 | Raw QUIC | 6/6 | PASS |
-| Red5 Pro | draft-14 | WebTransport | 6/6 | PASS |
-| Quicr libquicr | draft-14 | Raw QUIC | 5/6 | PASS |
+| Relay | Draft | Transport | ctrl-msg | pub-sub |
+|-------|-------|-----------|----------|---------|
+| OpenMoQ moqx | d14 | Raw QUIC | 6/6 | 3/3 |
+| OpenMoQ moqx | d14 | WebTransport | 6/6 | 3/3 |
+| OpenMoQ moqx | d16 | Raw QUIC | 6/6 | 3/3 |
+| OpenMoQ moqx | d16 | WebTransport | 6/6 | 3/3 |
+| Meta moxygen | d14 | Raw QUIC | 6/6 | 3/3 |
+| Meta moxygen | d14 | WebTransport | 6/6 | 3/3 |
+| Meta moxygen | d16 | Raw QUIC | 6/6 | 3/3 |
+| Meta moxygen | d16 | WebTransport | 6/6 | 3/3 |
+| Cloudflare moq-rs | d14 | Raw QUIC | 4/6 | 3/3 |
+| Red5 Pro | d14 | WebTransport | 6/6 | unverified |
+| Red5 Pro | d16 | WebTransport | 6/6 | unverified |
+| Quicr libquicr | d14 | Raw QUIC | 5/6 | 3/3 |
+| Quicr libquicr | d14 | WebTransport | 5/6 | 3/3 |
+| Quicr libquicr | d16 | Raw QUIC | unverified | unverified |
+| Quicr libquicr | d16 | WebTransport | 5/6 | 3/3 |
+
+Entries marked `unverified` did not complete successfully against our
+current client and are pending further investigation on our side or
+the peer's. A few relays in the catalog are disabled by default and
+can be re-probed individually with `--only`: `cdn.moq.dev/anon`
+(subscriber-only endpoint in our current test harness) and
+`quichemoq.dev` (connection did not complete during our probe).
 
 Test cases: `setup-only`, `announce-only`, `publish-namespace-done`,
-`subscribe-error`, `announce-subscribe`, `subscribe-before-announce`
+`subscribe-error`, `announce-subscribe`, `subscribe-before-announce`,
+plus `fetch` and `join` probes (not in default catalog matrix —
+most relays do not implement these yet).
 
 ## Development
 
@@ -280,7 +300,6 @@ with a specific Python version and Cython.
   - Interactive chat
   - MSF/LOC media packaging
   - CMSF media packaging
-* Dockerize interop test client for moq-interop-runner registration
 * Simple relay implementation
 
 ## Contributing


### PR DESCRIPTION
## Summary

- **ci.yml** (was pr.yml): triggers on **pull_request** AND **push to main**. Gives post-merge verification without adding skipped publish jobs to every run.
- **release.yml**: flipped from tag-push trigger to **workflow_dispatch only** with a \`version\` input. The workflow validates, creates the tag, runs the test matrix, publishes to TestPyPI → PyPI, cuts the GitHub Release, and pushes the Docker image. Owner-only via GitHub's default workflow_dispatch policy.
- **Dockerfile**: fixes the 0.8.1 docker-publish failure — \`.dockerignore\` excludes \`.git\`, so \`setuptools_scm\` had no version to derive. Accept a \`VERSION\` build-arg and set \`SETUPTOOLS_SCM_PRETEND_VERSION\`. Release workflow passes the tag via \`--build-arg\`.
- **README**: refreshed interop table with the full transport × draft matrix from v0.8.1 probes. Softened peer-relay non-completions to \`unverified\` rather than publishing failure detail.

## Test plan

- [x] \`docker build --build-arg VERSION=0.8.1 .\` succeeds locally
- [x] \`python tests/release-regression-test.py --test-tier unit --test-tier integration\` green locally
- [x] CI (\`test 3.12/3.13/3.14\`) green on this PR
- [ ] After merge: push to main fires ci.yml automatically
- [ ] Separately: dispatch release.yml for 0.8.2 when ready; verify tag creation + full pipeline including docker-publish

## Follow-up outside this PR

- Manually push \`ghcr.io/gmarzot/aiomoqt:0.8.1\` since the original docker-publish run failed. Can rebuild locally from the tag and push, or trigger a one-off workflow run.