### PR TITLE
v0.8.2 polish: docs + catalog + relay_probe CLI + runner quieter output

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a7fb8dc4-31fd-4ce7-b382-d0e8cb7c8dd0","pid":514099,"acquiredAt":1776814557220}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a7fb8dc4-31fd-4ce7-b382-d0e8cb7c8dd0","pid":514099,"acquiredAt":1776814557220}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ wheels/
 .DS_Store
 *.prof
 *.bin
+.claude/
+.vscode/settings.json.local

--- a/README.md
+++ b/README.md
@@ -252,25 +252,32 @@ Error codes are validated to spec-conformant values
 | Relay | Draft | Transport | ctrl-msg | pub-sub |
 |-------|-------|-----------|----------|---------|
 | OpenMoQ moqx | d14 | Raw QUIC | 6/6 | 3/3 |
-| OpenMoQ moqx | d14 | WebTransport | 6/6 | 3/3 |
+| OpenMoQ moqx | d14 | H3/WT | 6/6 | 3/3 |
 | OpenMoQ moqx | d16 | Raw QUIC | 6/6 | 3/3 |
-| OpenMoQ moqx | d16 | WebTransport | 6/6 | 3/3 |
+| OpenMoQ moqx | d16 | H3/WT | 6/6 | 3/3 |
 | Meta moxygen | d14 | Raw QUIC | 6/6 | 3/3 |
-| Meta moxygen | d14 | WebTransport | 6/6 | 3/3 |
+| Meta moxygen | d14 | H3/WT | 6/6 | 3/3 |
 | Meta moxygen | d16 | Raw QUIC | 6/6 | 3/3 |
-| Meta moxygen | d16 | WebTransport | 6/6 | 3/3 |
-| Cloudflare moq-rs | d14 | Raw QUIC | 4/6 | 3/3 |
-| Red5 Pro | d14 | WebTransport | 6/6 | unverified |
-| Red5 Pro | d16 | WebTransport | 6/6 | unverified |
+| Meta moxygen | d16 | H3/WT | 6/6 | 3/3 |
+| Cloudflare moq-rs | d14 | Raw QUIC | 5/6 | 3/3 |
+| Cloudflare moq-rs (draft-16, manish) | d16 | Raw QUIC | 6/6 | unverified |
+| Red5 Pro | d14 | H3/WT | 6/6 | unverified |
+| Red5 Pro | d16 | H3/WT | 6/6 | unverified |
 | Quicr libquicr | d14 | Raw QUIC | 5/6 | 3/3 |
-| Quicr libquicr | d14 | WebTransport | 5/6 | 3/3 |
+| Quicr libquicr | d14 | H3/WT | 5/6 | 3/3 |
 | Quicr libquicr | d16 | Raw QUIC | unverified | unverified |
-| Quicr libquicr | d16 | WebTransport | 5/6 | 3/3 |
+| Quicr libquicr | d16 | H3/WT | 5/6 | 3/3 |
+| Meetecho imquic | d16 | Raw QUIC | 6/6 | unverified |
+| Meetecho imquic | d16 | H3/WT | 5/6 | unverified |
+| OzU moqtail | d14 | H3/WT | 6/6 | unverified |
 
-Entries marked `unverified` did not complete successfully against our
+Entries marked `unverified` did not complete end-to-end against our
 current client and are pending further investigation on our side or
-the peer's. A few relays in the catalog are disabled by default and
-can be re-probed individually with `--only`: `cdn.moq.dev/anon`
+the peer's. Additional advertised endpoints that our client cannot
+yet complete a SETUP with are tracked in
+[`tests/relays.json`](tests/relays.json) (e.g. Red5's raw-QUIC port
+8443, Cloudflare draft-16 H3/WT, imquic draft-14). Fully disabled in
+the default catalog (re-probe with `--only`): `cdn.moq.dev/anon`
 (subscriber-only endpoint in our current test harness) and
 `quichemoq.dev` (connection did not complete during our probe).
 

--- a/README.md
+++ b/README.md
@@ -261,9 +261,10 @@ Error codes are validated to spec-conformant values
 | Meta moxygen | d16 | H3/WT | 6/6 | 3/3 |
 | Cloudflare moq-rs | d14 | QUIC | 5/6 | 3/3 |
 | Cloudflare moq-rs (d16 interop branch) | d16 | QUIC | 6/6 | unverified |
+| Red5 Pro | d14 | QUIC | unreachable | unreachable |
 | Red5 Pro | d14 | H3/WT | 6/6 | unverified |
+| Red5 Pro | d16 | QUIC | unreachable | unreachable |
 | Red5 Pro | d16 | H3/WT | 6/6 | unverified |
-| Red5 Pro | d14/d16 | QUIC | unreachable | unreachable |
 | Quicr libquicr | d14 | QUIC | 5/6 | 3/3 |
 | Quicr libquicr | d14 | H3/WT | 5/6 | 3/3 |
 | Quicr libquicr | d16 | QUIC | unverified | unverified |

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ an interop test client compatible with the
 - Version-independent API: `MOQTRequestError` exception across drafts
 - Async context manager for session lifecycle
 - High-level control message API with sync/async response handling
-- **Track API:** `PublishedTrack` / `SubscribedTrack` wrap stream setup,
-  subgroup/object writing, pacing, and FETCH/JOIN reassembly
-  (see [`aiomoqt.track`](aiomoqt/track.py))
+- **Track API** ([`aiomoqt.track`](aiomoqt/track.py)): `PublishedTrack` / `SubscribedTrack` wrap stream setup, subgroup writing, pacing, FETCH/JOIN reassembly
 - Low-level message serialization/deserialization
 - Pluggable message handlers via `register_handler()`
 - Data publishing via SubgroupHeader streams or ObjectDatagrams

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ python -m aiomoqt.examples.moq_interop_client -r "moqt://relay.ex.com:4433"
 python -m aiomoqt.examples.moq_interop_client -r "moqt://relay.ex.com:4433" --draft 16
 
 # Single test case
-python -m aiomoqt.examples.moq_interop_client -r "moqt://relay" -t subscribe-error
+python -m aiomoqt.examples.moq_interop_client -r "moqt://relay.ex.com:4433" -t subscribe-error
 
 # List test cases
 python -m aiomoqt.examples.moq_interop_client -l
@@ -207,12 +207,28 @@ python -m aiomoqt.examples.moq_interop_client -l
 
 ### Relay Probe
 
+Batch liveness + draft-version check. Reads a relay list, does a
+real CLIENT_SETUP / SERVER_SETUP handshake per (endpoint × draft) —
+no bare-ALPN tricks — and writes a JSON status report.
+
 ```bash
+# one-shot probe of RELAYS_FILE, write OUTPUT_FILE, exit
+PROBE_ONCE=1 RELAYS_FILE=relays.json OUTPUT_FILE=relay-status.json \
+  python -m aiomoqt.examples.relay_probe
+
+# long-running monitor: re-probe every PROBE_INTERVAL seconds
 python -m aiomoqt.examples.relay_probe
 ```
 
-Environment variables: `RELAYS_FILE`, `OUTPUT_FILE`,
-`PROBE_TIMEOUT`, `PROBE_INTERVAL`, `PROBE_ONCE`
+Environment variables:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `RELAYS_FILE` | `/app/relays.json` | input relay list |
+| `OUTPUT_FILE` | `/output/relay-status.json` | status report destination |
+| `PROBE_TIMEOUT` | `8` | per-probe handshake timeout (s) |
+| `PROBE_INTERVAL` | `300` | re-probe cadence in monitor mode (s) |
+| `PROBE_ONCE` | unset | if set, probe once and exit |
 
 ### WebTransport Server
 

--- a/README.md
+++ b/README.md
@@ -126,13 +126,6 @@ req = await session.subscribe('ns', 'track')
 
 ## Examples
 
-Examples and benchmarks accept relay URLs in two forms:
-
-```
-moqt://host[:port]              Raw QUIC (default port 443)
-https://host[:port]/[endpoint]  H3/WebTransport (default port 443)
-```
-
 ### Publisher / Subscriber
 
 ```bash
@@ -152,6 +145,13 @@ python -m aiomoqt.examples.join_example --host relay.ex.com --use-quic
 Common options: `--namespace`, `--trackname`, `--endpoint`, `--debug`, `--keylogfile`
 
 ### Benchmarks
+
+Bench tools take a positional relay URL:
+
+```
+moqt://host[:port]              Raw QUIC (default port 443)
+https://host[:port]/[endpoint]  H3/WebTransport (default port 443)
+```
 
 ```bash
 # Publisher — configurable size, rate, parallelism

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ pip install aiomoqt
 uv pip install aiomoqt
 ```
 
+> For a clean `uv`-managed dev setup with a pinned Python and Cython,
+> run `./bootstrap_python.sh` from a repo clone.
+
 ## Quick Start
 
 ### Subscriber

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ an interop test client compatible with the
 - H3/WebTransport and raw QUIC transports
 - **Draft-14/16:** ALPN negotiation (`moq-00` / `moqt-16`)
 - **Draft-16:** delta-encoded param keys, track extensions, unified request response
-- **Wire format:** SubgroupHeader/ObjectDatagram flag encoding, delta-encoded object IDs
+- Wire format: SubgroupHeader / ObjectDatagram flag encoding, delta-encoded object IDs
 - Version-independent API: `MOQTRequestError` exception across drafts
 - Async context manager for session lifecycle
 - High-level control message API with sync/async response handling
-- **Track API** ([`aiomoqt.track`](aiomoqt/track.py)): `PublishedTrack` / `SubscribedTrack` wrap stream setup, subgroup writing, pacing, FETCH/JOIN reassembly
+- High-level publisher API ([`PublishedTrack`](aiomoqt/track.py)): stream setup, subgroup writing, pacing
+- High-level subscriber API ([`SubscribedTrack`](aiomoqt/track.py)): object reassembly, FETCH / JOIN handling
 - Low-level message serialization/deserialization
 - Pluggable message handlers via `register_handler()`
 - Data publishing via SubgroupHeader streams or ObjectDatagrams

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install aiomoqt
 uv pip install aiomoqt
 ```
 
-**note:** `./bootstrap_python.sh` sets up a clean `uv`-managed environment with pinned Python and Cython, for convenience.
+**note:** `./bootstrap_python.sh` provided for easy `uv`-based Python venv install
 
 ## Quick Start
 
@@ -124,18 +124,14 @@ resp = await session.subscribe('ns', 'track', wait_response=True)
 req = await session.subscribe('ns', 'track')
 ```
 
-### Relay URL Formats
-
-Examples and benchmarks accept relay URLs in several forms:
-
-```
-moqt://host:port            Raw QUIC (default port 443)
-https://host:port/endpoint  H3/WebTransport (default port 443)
-host:port                   H3/WebTransport
-host                        H3/WebTransport, port 443, endpoint /moq
-```
-
 ## Examples
+
+Examples and benchmarks accept relay URLs in two forms:
+
+```
+moqt://host[:port]              Raw QUIC (default port 443)
+https://host[:port]/[endpoint]  H3/WebTransport (default port 443)
+```
 
 ### Publisher / Subscriber
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Error codes are validated to spec-conformant values
 | Cloudflare moq-rs (d16 interop branch) | d16 | QUIC | 6/6 | unverified |
 | Red5 Pro | d14 | H3/WT | 6/6 | unverified |
 | Red5 Pro | d16 | H3/WT | 6/6 | unverified |
+| Red5 Pro | d14/d16 | QUIC | unreachable | unreachable |
 | Quicr libquicr | d14 | QUIC | 5/6 | 3/3 |
 | Quicr libquicr | d14 | H3/WT | 5/6 | 3/3 |
 | Quicr libquicr | d16 | QUIC | unverified | unverified |
@@ -273,13 +274,16 @@ Error codes are validated to spec-conformant values
 
 Entries marked `unverified` did not complete end-to-end against our
 current client and are pending further investigation on our side or
-the peer's. Additional advertised endpoints that our client cannot
-yet complete a SETUP with are tracked in
-[`tests/relays.json`](tests/relays.json) (e.g. Red5's raw-QUIC port
-8443, Cloudflare draft-16 H3/WT, imquic draft-14). Fully disabled in
-the default catalog (re-probe with `--only`): `cdn.moq.dev/anon`
-(subscriber-only endpoint in our current test harness) and
-`quichemoq.dev` (connection did not complete during our probe).
+the peer's. `unreachable` means the UDP/QUIC handshake never got a
+response — Red5's advertised raw-QUIC endpoint
+`moqt://moq-relay.red5.net:8443` falls in this bucket on every draft
+we probe (their H3/WT on 4433 works fine). Additional advertised
+endpoints that our client cannot yet complete a SETUP with are
+tracked in [`tests/relays.json`](tests/relays.json) (e.g. Cloudflare
+draft-16 H3/WT, imquic draft-14). Fully disabled in the default
+catalog (re-probe with `--only`): `cdn.moq.dev/anon` (subscriber-only
+endpoint in our current test harness) and `quichemoq.dev` (connection
+did not complete during our probe).
 
 Test cases: `setup-only`, `announce-only`, `publish-namespace-done`,
 `subscribe-error`, `announce-subscribe`, `subscribe-before-announce`,

--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ an interop test client compatible with the
 ### Features
 
 - H3/WebTransport and raw QUIC transports
+- **Draft-14/16:** ALPN negotiation (`moq-00` / `moqt-16`)
+- **Draft-16:** delta-encoded param keys, track extensions, unified request response
+- **Wire format:** SubgroupHeader/ObjectDatagram flag encoding, delta-encoded object IDs
+- Version-independent API: `MOQTRequestError` exception across drafts
 - Async context manager for session lifecycle
 - High-level control message API with sync/async response handling
+- **Track API:** `PublishedTrack` / `SubscribedTrack` wrap stream setup,
+  subgroup/object writing, pacing, and FETCH/JOIN reassembly
+  (see [`aiomoqt.track`](aiomoqt/track.py))
 - Low-level message serialization/deserialization
-- Version-independent API: `MOQTRequestError` exception across drafts
 - Pluggable message handlers via `register_handler()`
 - Data publishing via SubgroupHeader streams or ObjectDatagrams
 - Data reception via `on_object_received` callback
-- **Draft-14/16:** ALPN negotiation (`moq-00` / `moqt-16`)
-- **Draft-16:** delta-encoded parameter keys, track extensions,
-  unified REQUEST_OK/REQUEST_ERROR
-- **Wire format:** SubgroupHeader/ObjectDatagram flag encoding,
-  delta-encoded object IDs
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -211,24 +211,27 @@ Batch liveness + draft-version check. Reads a relay list, does a
 real CLIENT_SETUP / SERVER_SETUP handshake per (endpoint × draft) —
 no bare-ALPN tricks — and writes a JSON status report.
 
+Accepts CLI flags, environment variables, or both (CLI overrides env):
+
 ```bash
-# one-shot probe of RELAYS_FILE, write OUTPUT_FILE, exit
-PROBE_ONCE=1 RELAYS_FILE=relays.json OUTPUT_FILE=relay-status.json \
+# CLI form (typical interactive use)
+python -m aiomoqt.examples.relay_probe -f relays.json -o status.json --once
+
+# Env form (typical container/daemon deployment)
+RELAYS_FILE=relays.json OUTPUT_FILE=status.json PROBE_ONCE=1 \
   python -m aiomoqt.examples.relay_probe
 
-# long-running monitor: re-probe every PROBE_INTERVAL seconds
-python -m aiomoqt.examples.relay_probe
+# Long-running monitor (re-probe every --interval seconds)
+python -m aiomoqt.examples.relay_probe -f relays.json -o status.json
 ```
 
-Environment variables:
-
-| Variable | Default | Meaning |
-|----------|---------|---------|
-| `RELAYS_FILE` | `/app/relays.json` | input relay list |
-| `OUTPUT_FILE` | `/output/relay-status.json` | status report destination |
-| `PROBE_TIMEOUT` | `8` | per-probe handshake timeout (s) |
-| `PROBE_INTERVAL` | `300` | re-probe cadence in monitor mode (s) |
-| `PROBE_ONCE` | unset | if set, probe once and exit |
+| CLI flag | Env var | Default | Meaning |
+|----------|---------|---------|---------|
+| `-f / --relays-file` | `RELAYS_FILE` | `/app/relays.json` | input relay list |
+| `-o / --output-file` | `OUTPUT_FILE` | `/output/relay-status.json` | status report destination |
+| `--timeout` | `PROBE_TIMEOUT` | `8` | per-probe handshake timeout (s) |
+| `--interval` | `PROBE_INTERVAL` | `300` | re-probe cadence in monitor mode (s) |
+| `--once` | `PROBE_ONCE=1` | unset | probe once and exit |
 
 ### WebTransport Server
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ Publisher flow selection (for relays that require a specific message pattern):
 
 ```bash
 # All tests (draft-14, auto-detected)
-python -m aiomoqt.examples.moq_interop_client -r "moqt://moqx-000.ci.openmoq.org:4433"
+python -m aiomoqt.examples.moq_interop_client -r "moqt://relay.ex.com:4433"
 
 # All tests (draft-16)
-python -m aiomoqt.examples.moq_interop_client -r "moqt://moqx-000.ci.openmoq.org:4433" --draft 16
+python -m aiomoqt.examples.moq_interop_client -r "moqt://relay.ex.com:4433" --draft 16
 
 # Single test case
 python -m aiomoqt.examples.moq_interop_client -r "moqt://relay" -t subscribe-error

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Error codes are validated to spec-conformant values
 | Meta moxygen | d16 | QUIC | 6/6 | 3/3 |
 | Meta moxygen | d16 | H3/WT | 6/6 | 3/3 |
 | Cloudflare moq-rs | d14 | QUIC | 5/6 | 3/3 |
-| Cloudflare moq-rs (draft-16, manish) | d16 | QUIC | 6/6 | unverified |
+| Cloudflare moq-rs (d16 interop branch) | d16 | QUIC | 6/6 | unverified |
 | Red5 Pro | d14 | H3/WT | 6/6 | unverified |
 | Red5 Pro | d16 | H3/WT | 6/6 | unverified |
 | Quicr libquicr | d14 | QUIC | 5/6 | 3/3 |

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ pip install aiomoqt
 uv pip install aiomoqt
 ```
 
-> For a clean `uv`-managed dev setup with a pinned Python and Cython,
-> run `./bootstrap_python.sh` from a repo clone.
+**note:** `./bootstrap_python.sh` sets up a clean `uv`-managed environment with pinned Python and Cython, for convenience.
 
 ## Quick Start
 
@@ -295,9 +294,6 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[test]"
 pytest aiomoqt/tests/
 ```
-
-Optionally, `./bootstrap_python.sh` sets up a full uv-managed environment
-with a specific Python version and Cython.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -251,23 +251,23 @@ Error codes are validated to spec-conformant values
 
 | Relay | Draft | Transport | ctrl-msg | pub-sub |
 |-------|-------|-----------|----------|---------|
-| OpenMoQ moqx | d14 | Raw QUIC | 6/6 | 3/3 |
+| OpenMoQ moqx | d14 | QUIC | 6/6 | 3/3 |
 | OpenMoQ moqx | d14 | H3/WT | 6/6 | 3/3 |
-| OpenMoQ moqx | d16 | Raw QUIC | 6/6 | 3/3 |
+| OpenMoQ moqx | d16 | QUIC | 6/6 | 3/3 |
 | OpenMoQ moqx | d16 | H3/WT | 6/6 | 3/3 |
-| Meta moxygen | d14 | Raw QUIC | 6/6 | 3/3 |
+| Meta moxygen | d14 | QUIC | 6/6 | 3/3 |
 | Meta moxygen | d14 | H3/WT | 6/6 | 3/3 |
-| Meta moxygen | d16 | Raw QUIC | 6/6 | 3/3 |
+| Meta moxygen | d16 | QUIC | 6/6 | 3/3 |
 | Meta moxygen | d16 | H3/WT | 6/6 | 3/3 |
-| Cloudflare moq-rs | d14 | Raw QUIC | 5/6 | 3/3 |
-| Cloudflare moq-rs (draft-16, manish) | d16 | Raw QUIC | 6/6 | unverified |
+| Cloudflare moq-rs | d14 | QUIC | 5/6 | 3/3 |
+| Cloudflare moq-rs (draft-16, manish) | d16 | QUIC | 6/6 | unverified |
 | Red5 Pro | d14 | H3/WT | 6/6 | unverified |
 | Red5 Pro | d16 | H3/WT | 6/6 | unverified |
-| Quicr libquicr | d14 | Raw QUIC | 5/6 | 3/3 |
+| Quicr libquicr | d14 | QUIC | 5/6 | 3/3 |
 | Quicr libquicr | d14 | H3/WT | 5/6 | 3/3 |
-| Quicr libquicr | d16 | Raw QUIC | unverified | unverified |
+| Quicr libquicr | d16 | QUIC | unverified | unverified |
 | Quicr libquicr | d16 | H3/WT | 5/6 | 3/3 |
-| Meetecho imquic | d16 | Raw QUIC | 6/6 | unverified |
+| Meetecho imquic | d16 | QUIC | 6/6 | unverified |
 | Meetecho imquic | d16 | H3/WT | 5/6 | unverified |
 | OzU moqtail | d14 | H3/WT | 6/6 | unverified |
 

--- a/README.md
+++ b/README.md
@@ -272,18 +272,10 @@ Error codes are validated to spec-conformant values
 | Meetecho imquic | d16 | H3/WT | 5/6 | unverified |
 | OzU moqtail | d14 | H3/WT | 6/6 | unverified |
 
-Entries marked `unverified` did not complete end-to-end against our
-current client and are pending further investigation on our side or
-the peer's. `unreachable` means the UDP/QUIC handshake never got a
-response — Red5's advertised raw-QUIC endpoint
-`moqt://moq-relay.red5.net:8443` falls in this bucket on every draft
-we probe (their H3/WT on 4433 works fine). Additional advertised
-endpoints that our client cannot yet complete a SETUP with are
-tracked in [`tests/relays.json`](tests/relays.json) (e.g. Cloudflare
-draft-16 H3/WT, imquic draft-14). Fully disabled in the default
-catalog (re-probe with `--only`): `cdn.moq.dev/anon` (subscriber-only
-endpoint in our current test harness) and `quichemoq.dev` (connection
-did not complete during our probe).
+- `unverified` — suite did not complete end-to-end.
+- `unreachable` — no response to QUIC Initial.
+- See [`tests/relays.json`](tests/relays.json) for the full catalog,
+  per-endpoint notes, and relays disabled by default.
 
 Test cases: `setup-only`, `announce-only`, `publish-namespace-done`,
 `subscribe-error`, `announce-subscribe`, `subscribe-before-announce`,

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,22 +25,19 @@ python tests/release-regression-test.py --test-tier interop --interop-parallel 4
 # 3. Adaptive throughput bench (measurement only; not a pass/fail gate)
 python tests/release-regression-test.py --test-tier bench
 
-# 4. Docker image builds cleanly (release workflow does this on tag;
-#    smoke-test locally if you've touched the Dockerfile or pyproject)
+# 4. Docker image smoke — build, list cases, run live against a known-good relay
 docker build --build-arg VERSION=0.0.0 -t aiomoqt-test .
 docker run --rm aiomoqt-test -l
+docker run --rm -e RELAY_URL=moqt://moqx-main.ci.openmoq.org:4433 \
+  aiomoqt-test --draft 14
 ```
 
 Pass criteria:
 
-- **(1)** all suites green. This one is blocking; don't tag if it fails.
-- **(2)** active relays green; `unverified` / `unreachable` entries
-  already noted in `tests/relays.json` are expected. New failures on
-  previously-green relays should be investigated.
-- **(3)** reports a ceiling (or `no ceiling up to N Mbps`) without
-  crashing. The number itself is host-dependent and not a gate —
-  useful for trend comparison against prior releases.
-- **(4)** image builds; `-l` lists the 8 test-case names.
+- **(1)** all green. Blocking.
+- **(2)** active relays green; known `unverified` / `unreachable` OK.
+- **(3)** reports a ceiling without crashing. Not a gate.
+- **(4)** build clean; `-l` lists 8 cases; live run exits 0.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,12 +1,46 @@
 # Pre-Release Test Plan
 
 This document is the checklist run before tagging a release. CI runs
-the same tiers automatically on every PR to main (`unit` +
-`integration`); the `interop` and `bench` tiers are owner-dispatched
-or run locally.
+the unit + integration tiers automatically on every PR to main; the
+interop and bench tiers are owner-dispatched or run locally.
 
 Bench tools auto-generate unique tracknames from test parameters to
 avoid stale-cache collisions on relays that key by (namespace, trackname).
+
+---
+
+## Pre-Release Checklist
+
+Before tagging, run these four high-level commands in order. Each is
+the "do them all" form of its tier — individual suites are spelled
+out in later sections but are not part of the release gate.
+
+```bash
+# 1. Unit + integration (CI will also run this on the PR)
+python tests/release-regression-test.py --test-tier unit --test-tier integration
+
+# 2. Interop across the active relay catalog
+python tests/release-regression-test.py --test-tier interop --interop-parallel 4
+
+# 3. Adaptive throughput bench (measurement only; not a pass/fail gate)
+python tests/release-regression-test.py --test-tier bench
+
+# 4. Docker image builds cleanly (release workflow does this on tag;
+#    smoke-test locally if you've touched the Dockerfile or pyproject)
+docker build --build-arg VERSION=0.0.0 -t aiomoqt-test .
+docker run --rm aiomoqt-test -l
+```
+
+Pass criteria:
+
+- **(1)** all suites green. This one is blocking; don't tag if it fails.
+- **(2)** active relays green; `unverified` / `unreachable` entries
+  already noted in `tests/relays.json` are expected. New failures on
+  previously-green relays should be investigated.
+- **(3)** reports a ceiling (or `no ceiling up to N Mbps`) without
+  crashing. The number itself is host-dependent and not a gate —
+  useful for trend comparison against prior releases.
+- **(4)** image builds; `-l` lists the 8 test-case names.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,9 +4,6 @@ This document is the checklist run before tagging a release. CI runs
 the unit + integration tiers automatically on every PR to main; the
 interop and bench tiers are owner-dispatched or run locally.
 
-Bench tools auto-generate unique tracknames from test parameters to
-avoid stale-cache collisions on relays that key by (namespace, trackname).
-
 ---
 
 ## Pre-Release Checklist
@@ -189,6 +186,10 @@ The runner covers `unit`, `integration`, `interop`, and `bench` tiers
 in one invocation. The sections below are for ad-hoc investigation
 against a local relay — useful during protocol work, not needed for a
 release gate.
+
+Bench tools (`pub_bench`, `sub_bench`, `relay_bench`, `multi_sub_bench`)
+auto-generate unique tracknames from test parameters to avoid
+stale-cache collisions on relays that key by (namespace, trackname).
 
 ### Local relay pub/sub — d16 raw QUIC, 500 KB objects
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,51 +1,97 @@
 # Pre-Release Test Plan
 
-Run all tests before tagging a release. All must pass.
+This document is the checklist run before tagging a release. CI runs
+the same tiers automatically on every PR to main (`unit` +
+`integration`); the `interop` and `bench` tiers are owner-dispatched
+or run locally.
 
 Bench tools auto-generate unique tracknames from test parameters to
-avoid relay cache collisions.
+avoid stale-cache collisions on relays that key by (namespace, trackname).
+
+---
+
+## Test Tiers
+
+| Tier | Network | CI-gated | Purpose |
+|------|---------|----------|---------|
+| `unit` | none | yes (PR) | pure-Python correctness; messages/track/buffer |
+| `integration` | localhost | yes (PR) | pub/sub + setup + join + fetch over in-process qh3 |
+| `interop` | public | manual / weekly | live relays in `tests/relays.json` |
+| `bench` | localhost or relay | manual | adaptive throughput ceiling measurement |
+
+Tier ≠ suite: a tier is just a named group of suites. The runner
+accepts either `--test-tier <tier>` (runs every suite in the tier)
+or `--test-suite <suite>` (runs a single suite, ignoring tier).
+
+---
+
+## Test Suites
+
+### `unit` tier
+- **`buffer`** — `tests/test_rebuf.py`; stream reassembly (object-boundary alignment, partial-chunk handling, subgroup reconstruction). Standalone script, not pytest.
+- **`message`** — `pytest aiomoqt/tests/test_messages.py`; round-trip serialization for every MoQT control message across d14 and d16.
+- **`track`** — `pytest aiomoqt/tests/test_track.py`; `PublishedTrack` / `SubscribedTrack` unit tests.
+
+### `integration` tier
+- **`loopback-setup`** — d14/d16 session handshake and `AUTH_TOKEN` parameter round-trip, in-process qh3.
+- **`loopback-pub-sub`** — `loopback_bench` at fixed rate; asserts throughput > 0 and zero loss.
+- **`loopback-join`** — `JOINING_SUBSCRIBE` with `ABSOLUTE` and `RELATIVE` fetch types.
+- **`loopback-fetch`** — standalone `FETCH` variants: joining-relative, explicit range, invalid-range rejection, unknown request-id rejection.
+
+### `interop` tier (per active relay × transport × draft)
+- **`relay-ctrl-msg`** — 6 control-plane conformance cases (setup, announce, publish-namespace-done, subscribe-error, announce-subscribe, subscribe-before-announce). Error codes are validated to spec-defined values — `INTERNAL_ERROR (0x0)` does not pass a conformance gate.
+- **`relay-pub-sub`** — 3-subscriber multi-sub bench against the relay; asserts N/N subscribers receive the published objects.
+- **`relay-join`** — `SUBSCRIBE + JOINING_FETCH` probe (most relays do not implement this yet; disabled by default in the catalog).
+- **`relay-fetch`** — standalone `FETCH` probe (same).
+
+### `bench` tier (manual dispatch only; not PR-gated)
+- **`loopback-adaptive-bench`** — ramps rate in steps, stops on loss / p99 latency growth / throughput shortfall, reports the last stable rate.
+
+---
 
 ## Automated runner
 
-`tests/release-regression-test.py` executes four tiers:
-
-- **unit**:        `buffer`, `message`, `track` — pure Python, no network
-- **integration**: `loopback-setup`, `loopback-pub-sub`, `loopback-join`,
-                   `loopback-fetch` — local pub/sub over QUIC, no relay
-- **interop**:     `relay-ctrl-msg`, `relay-pub-sub`, `relay-join`,
-                   `relay-fetch` × each relay in `tests/relays.json`
-                   × each supported transport / draft
-- **bench**:       `loopback-adaptive-bench` — manual dispatch only
-                   (not PR-gated; measures host throughput ceiling)
+`tests/release-regression-test.py` drives every tier. All commands are
+one-liners and chainable:
 
 ```bash
-# full unit + integration (CI path)
+# CI path — runs on every PR to main
 python tests/release-regression-test.py --test-tier unit --test-tier integration
 
-# tier selection (repeatable)
+# Single tier
 python tests/release-regression-test.py --test-tier unit
 python tests/release-regression-test.py --test-tier interop
 
-# individual suite (repeatable; ignores tier grouping)
+# Individual suite (bypasses tier grouping)
 python tests/release-regression-test.py --test-suite message
 python tests/release-regression-test.py --test-suite loopback-pub-sub --test-suite relay-ctrl-msg
 
-# interop runs relays in parallel; tune concurrency
+# Interop in parallel across relays
 python tests/release-regression-test.py --test-tier interop --interop-parallel 4
 
-# interop tier scoped to one relay from the catalog
+# Interop scoped to one relay (works on disabled entries too)
 python tests/release-regression-test.py --test-tier interop --only moqx-main
-python tests/release-regression-test.py --test-tier interop --only cloudflare-d14
 
-# alternate catalog
-python tests/release-regression-test.py --catalog /path/to/relays.json
+# Custom catalog
+python tests/release-regression-test.py --catalog /path/to/my-relays.json
+
+# Adaptive bench
+python tests/release-regression-test.py --test-tier bench
 ```
 
-Exit 0 iff every test passed. `[skip]` suites (per-relay `disabled_suites`)
-do not count. Per-test logs land in a temp directory printed at start/end
-of the run.
+Exit 0 iff every non-skipped test passed. `[skip]` entries (per-relay
+`disabled_suites` and fully `disabled` relays) do not contribute to
+pass/fail counts. Per-test logs land in a temp directory printed at
+the start and end of the run.
 
-To add a relay to the catalog, edit `tests/relays.json`:
+When `$GITHUB_STEP_SUMMARY` is set (GitHub Actions), the runner also
+emits a markdown summary table to the run-summary page.
+
+---
+
+## Relay catalog (adding and probing)
+
+Entries live in `tests/relays.json`. Full schema:
 
 ```json
 {
@@ -56,86 +102,43 @@ To add a relay to the catalog, edit `tests/relays.json`:
   },
   "drafts": [14, 16],
   "pub_mode": "publish",
+  "insecure": false,
+  "disabled": false,
   "disabled_suites": ["relay-join", "relay-fetch"],
   "notes": "freeform"
 }
 ```
 
-`pub_mode` selects the multi-sub publisher behavior for that relay:
-`publish` (default, sends PUBLISH only), `publish-ns` (PUBLISH_NAMESPACE
-only, waits for SUBSCRIBE), or `publish-both` (both messages; required
-by Cloudflare d14 moq-rs).
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `name` | yes | id used in output and `--only` |
+| `urls` | yes | map of `raw-quic` and/or `h3-wt` to full URL |
+| `drafts` | yes | supported MoQT draft numbers |
+| `pub_mode` | no (default `publish`) | `publish` sends only PUBLISH; `publish-ns` sends only PUBLISH_NAMESPACE; `publish-both` sends both (required by Cloudflare d14 moq-rs) |
+| `insecure` | no (default `false`) | if `true`, pass `--tls-disable-verify` / `-k` to subprocess tools |
+| `disabled` | no (default `false`) | if `true`, skip this relay entirely unless `--only` names it |
+| `disabled_suites` | no | list of suite names to skip for this relay (e.g. `["relay-join", "relay-fetch"]`) |
+| `notes` | no | freeform comment (not printed on skip lines) |
 
-`disabled_suites` lists interop suite names that should skip for this
-relay (most relays do not implement `relay-join` / `relay-fetch` yet).
-
-Sections below document the underlying commands for manual runs.
-
-## Prerequisites
-
-A local moqx relay and a remote one accessible at
-`moqx-000.ci.openmoq.org:4433`.
-
-## 1. Unit Tests
+Adding a new relay — minimal recipe:
 
 ```bash
-pytest aiomoqt/tests/ -v
+# 1. Add a stub entry
+# 2. Probe it manually
+python tests/release-regression-test.py --test-tier interop --only <your-name>
+# 3. Based on results, tune disabled_suites or set disabled: true
 ```
 
-Expected: all pass (messages + track + loopback-setup + loopback-join +
-loopback-fetch).
+---
 
-## 2. Buffer Reassembly Tests
+## Manual runs (what the automated runner doesn't cover)
 
-```bash
-python tests/test_rebuf.py
-```
+The runner covers `unit`, `integration`, `interop`, and `bench` tiers
+in one invocation. The sections below are for ad-hoc investigation
+against a local relay — useful during protocol work, not needed for a
+release gate.
 
-Expected: 6/6 pass
-
-## 2a. Adaptive Throughput Bench (manual)
-
-```bash
-python -m aiomoqt.examples.adaptive_bench --ramp 10,5,10,200
-```
-
-Ramps rate until buffer growth is observed. Reports the last stable
-rate. Use `-r <url> -k` for relay mode. Not in PR CI (variable on
-shared runners).
-
-## 3. Interop Tests (moqx-000 remote)
-
-### D14 H3/WebTransport
-```bash
-python -m aiomoqt.examples.moq_interop_client -r https://moqx-000.ci.openmoq.org:4433/moq-relay
-```
-
-### D14 Raw QUIC
-```bash
-python -m aiomoqt.examples.moq_interop_client -r moqt://moqx-000.ci.openmoq.org:4433
-```
-
-### D16 H3/WebTransport
-```bash
-python -m aiomoqt.examples.moq_interop_client -r https://moqx-000.ci.openmoq.org:4433/moq-relay --draft 16
-```
-
-### D16 Raw QUIC
-```bash
-python -m aiomoqt.examples.moq_interop_client -r moqt://moqx-000.ci.openmoq.org:4433 --draft 16
-```
-
-Expected: 6/6 pass on each (24/24 total)
-
-## 4. Loopback Benchmark
-
-```bash
-python -m aiomoqt.examples.loopback_bench -P 4 -s 16384 -r 60 -t 10
-```
-
-Expected: ~31 Mbps, ~240 obj/s, p50 latency <5ms
-
-## 5. Bench — D16 Raw QUIC, 500KB objects (local relay)
+### Local relay pub/sub — d16 raw QUIC, 500 KB objects
 
 Shell 1 (publisher):
 ```bash
@@ -147,96 +150,59 @@ Shell 2 (subscriber):
 python -m aiomoqt.examples.sub_bench moqt://moqx-local-000.marzresearch.net:4433 -k --draft 16
 ```
 
-Expected: ~116 Mbps, ~30 obj/s, zero loss, auto-discovers trackname
+Expected: ~116 Mbps, ~30 obj/s, zero loss, auto-discovered trackname.
 
-## 6. Bench — D16 Raw QUIC, 1KB, 4 streams (local relay)
+### Local relay pub/sub — d16 raw QUIC, 1 KB × 4 streams
 
-Shell 1 (publisher):
+Shell 1:
 ```bash
 python -m aiomoqt.examples.pub_bench moqt://moqx-local-000.marzresearch.net:4433 -s 1024 -t 120 -r 120 -g 60 -P 4 -k --draft 16
 ```
 
-Shell 2 (subscriber):
+Shell 2:
 ```bash
 python -m aiomoqt.examples.sub_bench moqt://moqx-local-000.marzresearch.net:4433 -k --draft 16
 ```
 
-Expected: ~480 obj/s, ~4 Mbps, p50 latency ~1ms
+Expected: ~480 obj/s, ~4 Mbps, p50 latency ~1 ms.
 
-## 7. Example — D16 Raw QUIC, 4 streams (local relay)
+### Local relay — d16 raw QUIC, max rate (congestion control)
 
-Shell 1 (publisher):
-```bash
-python -m aiomoqt.examples.pub_example --host moqx-local-000.marzresearch.net --port 4433 --use-quic --insecure --draft 16 --namespace test --trackname vid-d16q -P 4 -t 120
-```
-
-Shell 2 (subscriber):
-```bash
-python -m aiomoqt.examples.sub_example --host moqx-local-000.marzresearch.net --port 4433 --use-quic --insecure --draft 16 --namespace test --trackname vid-d16q
-```
-
-Expected: continuous data flow, ~30 obj/s
-
-## 8. Example — D14 Raw QUIC (local relay)
-
-Shell 1 (publisher):
-```bash
-python -m aiomoqt.examples.pub_example --host moqx-local-000.marzresearch.net --port 4433 --use-quic --insecure --namespace test --trackname vid-d14q -P 4 -t 120
-```
-
-Shell 2 (subscriber):
-```bash
-python -m aiomoqt.examples.sub_example --host moqx-local-000.marzresearch.net --port 4433 --use-quic --insecure --namespace test --trackname vid-d14q
-```
-
-Expected: continuous data flow, ~30 obj/s
-
-## 9. Example — D14 H3/WebTransport (local relay)
-
-Shell 1 (publisher):
-```bash
-python -m aiomoqt.examples.pub_example --host moqx-local-000.marzresearch.net --port 4433 --endpoint moq-relay --insecure --namespace test --trackname vid-d14wt -P 4
-```
-
-Shell 2 (subscriber):
-```bash
-python -m aiomoqt.examples.sub_example --host moqx-local-000.marzresearch.net --port 4433 --endpoint moq-relay --insecure --namespace test --trackname vid-d14wt
-```
-
-Expected: continuous data flow, ~30 obj/s
-
-## 10. Example — D16 Raw QUIC (remote relay)
-
-Shell 1 (publisher):
-```bash
-python -m aiomoqt.examples.pub_example --host moqx-000.ci.openmoq.org --port 4433 --use-quic --draft 16 --namespace test --trackname vid-d16q-remote -P 4
-```
-
-Shell 2 (subscriber):
-```bash
-python -m aiomoqt.examples.sub_example --host moqx-000.ci.openmoq.org --port 4433 --use-quic --draft 16 --namespace test --trackname vid-d16q-remote
-```
-
-Expected: continuous data flow, ~30 obj/s
-
-## 11. Bench — D16 Raw QUIC, max rate (local relay)
-
-Shell 1 (publisher):
+Shell 1:
 ```bash
 python -m aiomoqt.examples.pub_bench moqt://moqx-local-000.marzresearch.net:4433 -s 4096 -t 120 -g 1000 -P 4 -k --draft 16
 ```
 
-Shell 2 (subscriber):
+Shell 2:
 ```bash
 python -m aiomoqt.examples.sub_bench moqt://moqx-local-000.marzresearch.net:4433 -k --draft 16
 ```
 
-Expected: high throughput, tests congestion control under load
+Expected: sustained high throughput. Watch p99 latency and loss to
+see where your local loop saturates.
+
+---
+
+## moq-interop-runner integration
+
+aiomoqt ships a TAP v14-emitting client at
+`aiomoqt.examples.moq_interop_client` (the same module used internally
+by `relay-ctrl-msg`). The Dockerfile at the repo root builds an image
+consumable by [englishm/moq-interop-runner](https://github.com/englishm/moq-interop-runner).
+The published image is `ghcr.io/gmarzot/aiomoqt:<version>` and
+`:latest`; our `implementations.json` entry is wired up in an upstream
+PR. No local action is required to keep this path green — the release
+workflow pushes a fresh image on every tag.
+
+---
 
 ## Known Issues
 
-- Occasional corrupt timestamp extension at high throughput (re_buf
-  misalignment). Filtered in BenchStats, logged as warning.
-- moqx caches by (namespace, trackname); reusing a trackname after a
-  publisher size/rate change yields Payload mismatch. Bench tools
-  auto-generate unique tracknames per run.
+- Occasional corrupt timestamp extension at very high object rates
+  (reassembly buffer misalignment under stress). Filtered out in
+  `BenchStats`; logged as a warning.
+- moqx caches by `(namespace, trackname)`; reusing a trackname after a
+  publisher size/rate change yields a payload mismatch on subsequent
+  subscribers. Bench tools auto-generate unique tracknames per run to
+  avoid this — if you hand-roll commands against moqx, use a fresh
+  `--trackname` per run.

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,6 +15,13 @@ Before tagging, run these four high-level commands in order. Each is
 the "do them all" form of its tier — individual suites are spelled
 out in later sections but are not part of the release gate.
 
+Prerequisite: a **local MoQT relay running with real TLS certs**,
+reachable on the host doing the validation. The automated `integration`
+tier uses an in-process qh3 loopback (good for correctness, not for
+realistic throughput/fanout). The local relay is the environment that
+surfaces real-cert handshake, real network pacing, and multi-subscriber
+fanout behavior.
+
 ```bash
 # 1. Unit + integration (CI will also run this on the PR)
 python tests/release-regression-test.py --test-tier unit --test-tier integration
@@ -30,6 +37,18 @@ docker build --build-arg VERSION=0.0.0 -t aiomoqt-test .
 docker run --rm aiomoqt-test -l
 docker run --rm -e RELAY_URL=moqt://moqx-main.ci.openmoq.org:4433 \
   aiomoqt-test --draft 14
+
+# 5. Local relay — high-throughput pub/sub (d16 raw QUIC shown; run d14 and
+#    h3-wt variants too by swapping --draft and the URL scheme)
+#    Shell A (publisher):
+python -m aiomoqt.examples.pub_bench moqt://$LOCAL_RELAY:4433 \
+  -s 500000 -t 60 -r 30 -g 30 -k --draft 16
+#    Shell B (subscriber):
+python -m aiomoqt.examples.sub_bench moqt://$LOCAL_RELAY:4433 -k --draft 16
+
+# 6. Local relay — multi-subscriber fanout (pub + N subs in one process)
+python -m aiomoqt.examples.multi_sub_bench moqt://$LOCAL_RELAY:4433 \
+  -n 30 -s 1024 -r 60 -t 60 -k --draft 16
 ```
 
 Pass criteria:
@@ -38,6 +57,8 @@ Pass criteria:
 - **(2)** active relays green; known `unverified` / `unreachable` OK.
 - **(3)** reports a ceiling without crashing. Not a gate.
 - **(4)** build clean; `-l` lists 8 cases; live run exits 0.
+- **(5)** > 100 Mbps sustained, zero loss, p50 < ~5 ms.
+- **(6)** N/N subscribers ok, zero resets.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,18 +8,13 @@ interop and bench tiers are owner-dispatched or run locally.
 
 ## Pre-Release Checklist
 
-Before tagging, run these four high-level commands in order. Each is
-the "do them all" form of its tier — individual suites are spelled
-out in later sections but are not part of the release gate.
+Before tagging a new release, run these four high-level commands in order taking argumenbts to cover all test suites in each tier. The automated `integration` tier uses an in-process qh3 loopback. The local relay provides a higher fidelity test target for performance a can conformance verification
 
-Prerequisite: a **local MoQT relay running with real TLS certs**,
-reachable on the host doing the validation. The automated `integration`
-tier uses an in-process qh3 loopback (good for correctness, not for
-realistic throughput/fanout). The local relay is the environment that
-surfaces real-cert handshake, real network pacing, and multi-subscriber
-fanout behavior.
+Prerequisite: **MOQ relay instance w/ certs** (local or remote, either works). Export its URL once:
 
 ```bash
+export RELAY=moqt://your-relay.example:4433
+
 # 1. Unit + integration (CI will also run this on the PR)
 python tests/release-regression-test.py --test-tier unit --test-tier integration
 
@@ -29,23 +24,19 @@ python tests/release-regression-test.py --test-tier interop --interop-parallel 4
 # 3. Adaptive throughput bench (measurement only; not a pass/fail gate)
 python tests/release-regression-test.py --test-tier bench
 
-# 4. Docker image smoke — build, list cases, run live against a known-good relay
+# 4. Docker image smoke — build, list cases, run live
 docker build --build-arg VERSION=0.0.0 -t aiomoqt-test .
 docker run --rm aiomoqt-test -l
-docker run --rm -e RELAY_URL=moqt://moqx-main.ci.openmoq.org:4433 \
-  aiomoqt-test --draft 14
+docker run --rm --network host -e RELAY_URL=$RELAY aiomoqt-test --draft 14
 
-# 5. Local relay — high-throughput pub/sub (d16 raw QUIC shown; run d14 and
-#    h3-wt variants too by swapping --draft and the URL scheme)
+# 5. Throughput pub/sub (d14/d16 QUIC/WebTransport)
 #    Shell A (publisher):
-python -m aiomoqt.examples.pub_bench moqt://$LOCAL_RELAY:4433 \
-  -s 500000 -t 60 -r 30 -g 30 -k --draft 16
+python -m aiomoqt.examples.pub_bench $RELAY -s 500000 -t 60 -r 30 -g 30 -k --draft 16
 #    Shell B (subscriber):
-python -m aiomoqt.examples.sub_bench moqt://$LOCAL_RELAY:4433 -k --draft 16
+python -m aiomoqt.examples.sub_bench $RELAY -k --draft 16
 
-# 6. Local relay — multi-subscriber fanout (pub + N subs in one process)
-python -m aiomoqt.examples.multi_sub_bench moqt://$LOCAL_RELAY:4433 \
-  -n 30 -s 1024 -r 60 -t 60 -k --draft 16
+# 6. Multi-subscriber fanout (pub + N subs in one process)
+python -m aiomoqt.examples.multi_sub_bench $RELAY -n 30 -s 1024 -r 60 -t 60 -k --draft 16
 ```
 
 Pass criteria:

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -33,10 +33,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger("relay-probe")
 
+# Runtime config. Values read from env at import time so existing
+# container deployments keep working; the CLI parser in __main__
+# rebinds these from argparse defaults when the module is invoked
+# directly, giving CLI-over-env precedence.
 PROBE_TIMEOUT = int(os.getenv("PROBE_TIMEOUT", "8"))
 PROBE_INTERVAL = int(os.getenv("PROBE_INTERVAL", "300"))
 RELAYS_FILE = os.getenv("RELAYS_FILE", "/app/relays.json")
 OUTPUT_FILE = os.getenv("OUTPUT_FILE", "/output/relay-status.json")
+PROBE_ONCE = os.getenv("PROBE_ONCE", "").lower() in ("1", "true", "yes")
 
 # Draft versions to probe, oldest first — d14 bare WT CONNECT must
 # run before d16 (which sends wt-available-protocols) to avoid
@@ -232,7 +237,6 @@ async def run_loop():
             ]},
         ]
 
-    once = os.getenv("PROBE_ONCE", "").lower() in ("1", "true", "yes")
     last_probed = {}  # relay_id -> monotonic time of last probe
     cached_results = {}  # relay_id -> last probe result
 
@@ -246,35 +250,60 @@ async def run_loop():
         tmp.rename(out)
         logger.info(f"Wrote {out}")
 
-        if once:
+        if PROBE_ONCE:
             break
 
         logger.info(f"Next probe in {PROBE_INTERVAL}s")
         await asyncio.sleep(PROBE_INTERVAL)
 
 
-if __name__ == "__main__":
+def _parse_args():
     import argparse
-    parser = argparse.ArgumentParser(
+    p = argparse.ArgumentParser(
         prog="python -m aiomoqt.examples.relay_probe",
-        description="MOQ relay probe — probes relays for liveness and draft version support.",
-        epilog="""environment variables:
-  RELAYS_FILE      path to relay list JSON (default: /app/relays.json)
-  OUTPUT_FILE      status JSON output path (default: /output/relay-status.json)
-  PROBE_TIMEOUT    per-probe timeout in seconds (default: 8)
-  PROBE_INTERVAL   seconds between probe cycles (default: 300)
-  PROBE_ONCE       set "1" for single run then exit (default: loop)
-
-Reads RELAYS_FILE for relay definitions. If not found, uses built-in
-defaults (OpenMoQ, Meta moxygen, Cloudflare). Each relay endpoint is
-probed for draft-16 and draft-14 support. Results are written as JSON
-to OUTPUT_FILE.
-
-Relays may specify a per-relay "interval" (seconds) in relays.json
-to override PROBE_INTERVAL for that relay. Cached results are used
-between probes.
-""",
+        description="MOQ relay probe — liveness and draft-version check.",
+        epilog=(
+            "Each CLI flag defaults from its matching environment "
+            "variable (RELAYS_FILE, OUTPUT_FILE, PROBE_TIMEOUT, "
+            "PROBE_INTERVAL, PROBE_ONCE), so container deployments "
+            "that set env vars keep working unchanged. CLI flags "
+            "override env. A per-relay 'interval' field in the "
+            "relays file overrides --interval for that relay. "
+            "If the relays file is missing, a small built-in list "
+            "is used so the process always has something to probe."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.parse_args()
+    p.add_argument(
+        "-f", "--relays-file", default=RELAYS_FILE, metavar="PATH",
+        help=f"input relay list JSON (env: RELAYS_FILE; "
+             f"default: {RELAYS_FILE!r})")
+    p.add_argument(
+        "-o", "--output-file", default=OUTPUT_FILE, metavar="PATH",
+        help=f"status JSON output path (env: OUTPUT_FILE; "
+             f"default: {OUTPUT_FILE!r})")
+    p.add_argument(
+        "--timeout", type=int, default=PROBE_TIMEOUT, metavar="SEC",
+        help=f"per-probe handshake timeout (env: PROBE_TIMEOUT; "
+             f"default: {PROBE_TIMEOUT})")
+    p.add_argument(
+        "--interval", type=int, default=PROBE_INTERVAL, metavar="SEC",
+        help=f"seconds between probe cycles (env: PROBE_INTERVAL; "
+             f"default: {PROBE_INTERVAL})")
+    p.add_argument(
+        "--once", action="store_true", default=PROBE_ONCE,
+        help="probe once and exit (env: PROBE_ONCE=1)")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    # CLI overrides env overrides hard default. Rebinding module-level
+    # constants keeps existing references in probe_version / probe_all
+    # / run_loop working with zero signature churn.
+    RELAYS_FILE = args.relays_file
+    OUTPUT_FILE = args.output_file
+    PROBE_TIMEOUT = args.timeout
+    PROBE_INTERVAL = args.interval
+    PROBE_ONCE = args.once
     asyncio.run(run_loop())

--- a/tests/relays.json
+++ b/tests/relays.json
@@ -83,7 +83,38 @@
       "drafts": [14, 16],
       "pub_mode": "publish",
       "disabled_suites": ["relay-join", "relay-fetch", "relay-pub-sub"],
-      "notes": "Red5 Pro (endpoint /moq, not /moq-relay). ctrl-msg 6/6 clean on d14+d16; pub-sub subscribers get reset 0/3 — disabled pending investigation."
+      "notes": "Red5 Pro picoquic (endpoint /moq, not /moq-relay). ctrl-msg 6/6 clean on d14+d16; pub-sub subscribers get reset 0/3 — disabled pending investigation. Raw-quic endpoint moqt://moq-relay.red5.net:8443 is advertised in upstream registries but does not complete SETUP for us (ConnectionError) — unverified."
+    },
+    {
+      "name": "moqtail",
+      "urls": {
+        "h3-wt": "https://relay.moqtail.dev"
+      },
+      "drafts": [14],
+      "pub_mode": "publish",
+      "disabled_suites": ["relay-join", "relay-fetch"],
+      "notes": "OzU moqtail (Rust). WT d14 only."
+    },
+    {
+      "name": "imquic",
+      "urls": {
+        "raw-quic": "moqt://lminiero.it:9000",
+        "h3-wt":    "https://lminiero.it:9000"
+      },
+      "drafts": [16],
+      "pub_mode": "publish",
+      "disabled_suites": ["relay-join", "relay-fetch"],
+      "notes": "Meetecho imquic (C). d14 probes rejected (WT: \"No WebTransport protocol offered\"; QUIC close 376); only d16 tested here."
+    },
+    {
+      "name": "cf-d16-manish",
+      "urls": {
+        "raw-quic": "moqt://draft-16-manish.cloudflare.mediaoverquic.com:443"
+      },
+      "drafts": [16],
+      "pub_mode": "publish",
+      "disabled_suites": ["relay-join", "relay-fetch"],
+      "notes": "Cloudflare moq-rs draft-16 interop branch (itzmanish PR #131). WT endpoint https://.../moq is advertised but our client hits a SETUP parse error (\"Read out of bounds\") — raw QUIC only here until that's resolved."
     }
   ]
 }

--- a/tests/relays.json
+++ b/tests/relays.json
@@ -107,14 +107,14 @@
       "notes": "Meetecho imquic (C). d14 probes rejected (WT: \"No WebTransport protocol offered\"; QUIC close 376); only d16 tested here."
     },
     {
-      "name": "cf-d16-manish",
+      "name": "cf-d16-interop",
       "urls": {
         "raw-quic": "moqt://draft-16-manish.cloudflare.mediaoverquic.com:443"
       },
       "drafts": [16],
       "pub_mode": "publish",
       "disabled_suites": ["relay-join", "relay-fetch"],
-      "notes": "Cloudflare moq-rs draft-16 interop branch (itzmanish PR #131). WT endpoint https://.../moq is advertised but our client hits a SETUP parse error (\"Read out of bounds\") — raw QUIC only here until that's resolved."
+      "notes": "Cloudflare moq-rs draft-16 interop branch. Upstream also advertises an H3/WT endpoint at https://.../moq but our client hits a SETUP parse error (\"Read out of bounds\") — QUIC only here until that's resolved."
     }
   ]
 }

--- a/tests/release-regression-test.py
+++ b/tests/release-regression-test.py
@@ -267,19 +267,27 @@ def _run_relay_matrix(relay: dict, enabled: set[str],
 
     def _dispatch(suite: str, label_suffix: str, tag: str, slug: str,
                   fn, *fn_args) -> None:
-        label = f"{suite}{label_suffix} {rname} {tag}"
+        # Order label so the eye can scan relay-then-transport-then-suite
+        label = f"{rname:<14} {tag:<14} {suite}{label_suffix}"
         if suite in disabled:
-            marker = ("(disabled: JOIN not supported)" if suite == "relay-join"
-                      else "(disabled: FETCH not supported)" if suite == "relay-fetch"
-                      else f"(disabled: {relay.get('notes', 'not supported')})")
+            # Relay-join / relay-fetch are disabled on almost every
+            # relay by default — don't print a line per combo, just
+            # record the SKIP for the summary. Real relay-specific
+            # disables (e.g. red5 pub-sub) still announce themselves.
+            default_disabled = suite in ("relay-join", "relay-fetch")
+            if default_disabled:
+                marker = f"(disabled: {suite.split('-')[-1].upper()} "
+                marker += "not supported)"
+                results.append(("SKIP", label, marker, Path("/dev/null")))
+                return
+            marker = f"(disabled: {relay.get('notes', 'not supported')})"
             results.append(("SKIP", label, marker, Path("/dev/null")))
             _progress(f"  [skip] {label}  {marker}")
             return
         log = log_dir / f"{suite}_{slug}.log"
-        _progress(f"  ...   {label} running")
         status, detail = fn(*fn_args, log)
         results.append((status, label, detail, log))
-        marker = "[✓]  " if status == "PASS" else "[✗]  "
+        marker = "[PASS]" if status == "PASS" else "[FAIL]"
         _progress(f"  {marker} {label}  {detail}")
 
     for transport, url in relay["urls"].items():
@@ -359,11 +367,6 @@ def main() -> int:
             return 2
     else:
         relays = [r for r in relays_all if not r.get("disabled", False)]
-        disabled_names = [r["name"] for r in relays_all
-                          if r.get("disabled", False)]
-        if disabled_names:
-            print(f"  (disabled relays, use --only to probe: "
-                  f"{', '.join(disabled_names)})")
 
     results: list[Result] = []
 
@@ -447,13 +450,21 @@ def main() -> int:
                               log_dir / "loopback-adaptive-bench.log"))
 
     # --- summary ---
-    print("\n" + "═" * 60)
+    print("\n" + "═" * 72)
     fails = [r for r in results if r[0] == "FAIL"]
     skips = [r for r in results if r[0] == "SKIP"]
     passes = [r for r in results if r[0] == "PASS"]
+    # Hide default-disabled relay-join/relay-fetch SKIPs from the
+    # summary block — they are a permanent property of every active
+    # relay in the catalog and only add noise. The SKIP count still
+    # reflects them.
     for res in results:
-        print(f"  {res[0]:<4}  {res[1]:<42} {res[2]}")
-    print("═" * 60)
+        if res[0] == "SKIP" and (
+                "JOIN not supported" in res[2]
+                or "FETCH not supported" in res[2]):
+            continue
+        print(f"  {res[0]:<4}  {res[1]:<50} {res[2]}")
+    print("═" * 72)
     print(f"  Logs: {log_dir}")
     print(f"  {len(passes)} passed, {len(fails)} failed, {len(skips)} skipped")
 

--- a/tests/release-regression-test.py
+++ b/tests/release-regression-test.py
@@ -273,14 +273,14 @@ def _run_relay_matrix(relay: dict, enabled: set[str],
             # Relay-join / relay-fetch are disabled on almost every
             # relay by default — don't print a line per combo, just
             # record the SKIP for the summary. Real relay-specific
-            # disables (e.g. red5 pub-sub) still announce themselves.
+            # disables still announce themselves on a single line.
             default_disabled = suite in ("relay-join", "relay-fetch")
             if default_disabled:
                 marker = f"(disabled: {suite.split('-')[-1].upper()} "
                 marker += "not supported)"
                 results.append(("SKIP", label, marker, Path("/dev/null")))
                 return
-            marker = f"(disabled: {relay.get('notes', 'not supported')})"
+            marker = "(disabled for this relay)"
             results.append(("SKIP", label, marker, Path("/dev/null")))
             _progress(f"  [skip] {label}  {marker}")
             return


### PR DESCRIPTION
This is the tail of commits that were on the \`ci-restructure\` branch after PR #7 merged at \`a433c2a\`. GitHub's PR head pointer didn't follow the branch ref after that point, so the subsequent pushes didn't make it into PR #7. Raising here so they land on main.

## What's in this PR

### Runner
- Quieter interop output (\`[PASS]\`/\`[FAIL]\`/\`[skip]\` tokens, drop '...running' spam, columns reordered relay→transport→suite).
- Skip lines no longer dump relay notes — just \`(disabled for this relay)\`. Catalog notes stay in the catalog.
- Default-disabled \`relay-join\`/\`relay-fetch\` SKIPs suppressed from live + summary (they're a permanent property of every active relay; the totals still count them).

### Catalog (\`tests/relays.json\`)
- Add 3 working relays: \`moqtail\` (d14 WT), \`imquic\` (d16 both transports), \`cf-d16-interop\` (Cloudflare moq-rs draft-16 branch, raw-QUIC).
- Red5 raw-QUIC 8443 documented as unreachable in \`red5-moq\` notes (no QUIC handshake response from our client).
- Catalog key rename: \`cf-d16-manish\` → \`cf-d16-interop\` (avoid calling individuals out by handle).

### README
- Interop table: \`Raw QUIC\` → \`QUIC\`, \`WebTransport\` → \`H3/WT\`, add 3 new rows (moqtail/imquic/cf-d16-interop d16), split Red5 QUIC into per-draft rows (both unreachable), add \`unverified\` / \`unreachable\` legend below table.
- Features: split Track API into publisher+subscriber bullets (peers of control-message API); drop bold on non-draft labels.
- Installation: \`**note:**\` about \`./bootstrap_python.sh\`.
- Move Relay URL Formats from Quick Start to Benchmarks (the only tools that take a positional URL).
- Flesh out Relay Probe section (what it does, both invocation styles, full env/flag table).
- Scrub specific public relay hostnames from example commands.
- Simplify \`moqt://host[:port]\` URL form list.
- Drop shipped \"Dockerize interop test client\" TODO.

### TESTING.md
- Full rewrite: Pre-Release Checklist at the top (6 steps unified on \$RELAY), Test Tiers + Test Suites reference, Automated runner, Catalog schema, Manual runs trimmed.
- Local relay with real certs promoted to first-class pre-release step (covers real-cert handshake + pacing + fanout that the in-process qh3 loopback doesn't).

### relay_probe
- Real CLI flags: \`-f/--relays-file\`, \`-o/--output-file\`, \`--timeout\`, \`--interval\`, \`--once\`.
- Each flag defaults from its matching env var (RELAYS_FILE / OUTPUT_FILE / PROBE_TIMEOUT / PROBE_INTERVAL / PROBE_ONCE) so the moqarena container deployment keeps working unchanged. CLI > env > hard default.

### Misc
- \`.gitignore\` \`.claude/\` so Claude Code's runtime lockfile doesn't sneak into commits.

## Test plan

- [x] \`python tests/release-regression-test.py --test-tier unit --test-tier integration\` — all green locally
- [x] \`python -m aiomoqt.examples.relay_probe --once -f …\` — verified end-to-end with CLI flags
- [x] Output shape of interop tier verified against all 7 active relays
- [ ] CI matrix passes on this PR