### PR TITLE
Harden bench tooling against under-load stream corruption

### DIFF
--- a/aiomoqt/examples/_bench_workers.py
+++ b/aiomoqt/examples/_bench_workers.py
@@ -63,9 +63,12 @@ class _RollingStats:
         lat_ms = None
         exts = getattr(msg, 'extensions', None) or {}
         send_ms = exts.get(0x20)
-        if send_ms is not None and recv_time_ms is not None \
-                and abs(recv_time_ms - send_ms) < 60000:
-            lat_ms = recv_time_ms - send_ms
+        if send_ms is not None and recv_time_ms is not None:
+            raw = recv_time_ms - send_ms
+            # Reject negatives + absurd values from deframer garbage;
+            # accept up to 10 minutes (real under-load latency).
+            if -1000 <= raw <= 600_000:
+                lat_ms = raw
         self._events.append((t, size_bytes, lat_ms))
         self._total_bytes += size_bytes
         self._total_objs += 1

--- a/aiomoqt/examples/adaptive_bench.py
+++ b/aiomoqt/examples/adaptive_bench.py
@@ -165,7 +165,11 @@ class LiveStats:
         latency = None
         if send_ms is not None:
             raw = recv_time_ms - send_ms
-            if abs(raw) < 60000:
+            # Accept up to 10 minutes (under load latency really can
+            # exceed 60s); reject negatives and absurd values that
+            # come from deframer garbage (varint misdecode gives
+            # send_ms = 2^40-ish).
+            if -1000 <= raw <= 600_000:
                 latency = raw
                 if self._last_recv_ms and self._last_send_ms:
                     d = abs((recv_time_ms - self._last_recv_ms)

--- a/aiomoqt/examples/sub_bench.py
+++ b/aiomoqt/examples/sub_bench.py
@@ -80,8 +80,12 @@ class BenchStats:
                    if msg.extensions else None)
         if send_ms is not None:
             latency = recv_time_ms - send_ms
-            # Reject corrupt timestamps (>60s latency = parse error)
-            if abs(latency) > 60000:
+            # Reject genuinely corrupt timestamps — negatives and
+            # absurdly-large values (varint-garbage from a misaligned
+            # deframer pulls values like 2^40 which make the minute-
+            # threshold trip on real data). Real under-load latency
+            # can legitimately exceed 60s; cap at 10 minutes.
+            if latency < -1000 or latency > 600_000:
                 logger.warning(f"BenchStats: corrupt timestamp: "
                                f"send={send_ms} recv={recv_time_ms}")
                 send_ms = None

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -530,13 +530,31 @@ class MOQTSession(QuicConnectionProtocol):
                     needed = 1  # just get the next msg_buf - we dont know amount needed
                     break
                 except Exception as e:
-                    # Dump buffer state for debugging parse failures
+                    # Data-plane parse failure — the deframer lost its
+                    # alignment on this stream. Abandon the stream via
+                    # STOP_SENDING and keep the session alive; other
+                    # concurrent subgroup streams are unaffected.
+                    # Pre-hardening, this raised and killed the whole
+                    # session, taking down every in-flight subscription.
                     tell = msg_buf.tell()
-                    hex_at = msg_buf.data_slice(max(0, cur_pos), min(msg_len, cur_pos + 40)).hex()
-                    logger.error(f"MOQT stream({stream_id}): PARSE EXCEPTION at cur_pos={cur_pos} tell={tell} msg_len={msg_len} "
-                                 f"needed_was={needed} hex@cur_pos={hex_at} "
-                                 f"object_id={object_id} group_id={group_id}")
-                    raise
+                    hex_at = msg_buf.data_slice(
+                        max(0, cur_pos),
+                        min(msg_len, cur_pos + 40),
+                    ).hex()
+                    logger.error(
+                        f"MOQT stream({stream_id}): PARSE EXCEPTION "
+                        f"at cur_pos={cur_pos} tell={tell} "
+                        f"msg_len={msg_len} needed_was={needed} "
+                        f"hex@cur_pos={hex_at} "
+                        f"object_id={object_id} group_id={group_id} "
+                        f"exc={type(e).__name__}: {e}"
+                    )
+                    self._reject_stream(
+                        stream_id,
+                        SessionCloseCode.PROTOCOL_VIOLATION,
+                        f"parse error: {type(e).__name__}",
+                    )
+                    return
 
                 if msg_obj is None:
                     error = f"MOQT error: data stream({stream_id}):: parsing failed at position: "


### PR DESCRIPTION
## Summary

Two hardening fixes observed while load-testing v0.8.2 against a local moqx relay.

### 1. Bench latency filters reject real signal as 'corrupt'

`adaptive_bench`, `_bench_workers`, and `sub_bench` all had an `abs(latency) < 60000` filter that silently dropped any sample with more than 60s end-to-end latency as a parse error. Under queue pressure — exactly the situation bench tools are built to observe — legitimate latency samples cross 60s and grow from there (p99=42s observed rising past 60s in a 91-second run).

Fix: accept `[-1s, 10min]` as real; reject negatives and absurd values (the deframer can emit varint-garbage send timestamps like 2^40 after alignment loss, and those remain classified as corrupt).

### 2. One parse exception killed the whole subscriber session

In `MOQTSession._process_data_stream`, the generic `except Exception` clause called `raise`. This propagated out of the stream task and, via the session close path, killed every concurrent subscription on that session. Under load, a single bad subgroup stream takes down N healthy ones.

Fix: send `STOP_SENDING` for the corrupted stream (reusing `_reject_stream` with `PROTOCOL_VIOLATION`) and `return` from the task instead of re-raising. Other subgroup streams on the same session continue unaffected. Logs still include the hex dump + exception type for diagnosis.

## What this is NOT

The actual framer desync is a real pre-existing bug. Symptoms are visible from both sides:

- **Client parse side**: `ObjectStatus value=50` (ASCII '2' pulled from what should be a payload), `ext_len: 1002159035`, `send=1099511627776` (2^40 varint garbage), `bbbb...` freed-buffer fill pattern.
- **Relay side** (from moqx logs): `publishDone for invalid id=1`, `Trying to publish after publishDone`, `Write after stream complete or reset`.

Together these indicate the publish path doesn't cleanly honor the subgroup stream lifecycle (BEGIN → OBJECT* → END) under concurrent pressure. Root-causing it requires non-trivial work in protocol.py / track.py, which is deferred — likely addressed as part of the aiopquic pivot rather than landed on the qh3 branch.

## Test plan

- [x] adaptive_bench loopback: unchanged behavior (20→30→40 Mbps ramp clean)
- [x] Hardening fixes exercise no new code paths on healthy runs — only matter under stress
- [x] Full regression: run unit + integration + bench + interop before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)