### PR TITLE
qh3 1.8.0 forward-compat shim (perf-test branch)

### DIFF
--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -1486,10 +1486,16 @@ class MOQTSession(QuicConnectionProtocol):
         stream = self._quic._streams.get(stream_id)
         if stream is None:
             return True  # stream not yet registered — allow write
-        if stream.sender._reset_error_code is not None:
-            return False
-        if stream.sender._buffer_fin is not None:
-            return False  # FIN already queued (close() sent it)
+        sender = stream.sender
+        # qh3 1.8.0 (patch-perf) renamed internals → boolean properties.
+        if hasattr(sender, 'reset_pending'):
+            if sender.reset_pending or sender.is_finished:
+                return False
+        else:
+            if sender._reset_error_code is not None:
+                return False
+            if sender._buffer_fin is not None:
+                return False
         return True
 
     async def stream_write_drain(self, stream_id: int, data: bytes,


### PR DESCRIPTION
## What

Forward-compatibility shim in \`aiomoqt/protocol.py\` for qh3 1.8.0 (the as-yet-unreleased \`patch-perf\` branch on \`jawah/qh3\` — see [PR #115](https://github.com/jawah/qh3/pull/115)).

\`QuicStreamSender\` was refactored: private \`_reset_error_code\` / \`_buffer_fin\` → public boolean properties \`reset_pending\` / \`is_finished\`. \`_stream_is_writable()\` now picks the right API at runtime via \`hasattr\` — works on 1.7.4 today, ready for 1.8.0 when it ships.

## Why

PR #115 claims up to 30% throughput improvement. Wanted to validate before bumping the qh3 pin.

## Perf results (qh3 1.7.4 vs 1.8.0 patch-perf, both on this branch)

| Workload (\`-s 4096 -t 15\`) | qh3 1.7.4 | qh3 1.8.0 patch-perf | Δ |
|---|---|---|---|
| Loopback (single process) | 2229 obj/s, 73 Mbps | 2610 obj/s, 86 Mbps | **+17%** |
| Through local moqx relay (3 procs) | 5455 obj/s, 179 Mbps | 5954 obj/s, 196 Mbps | **+9%** |

3 runs each, median reported. Real, repeatable; smaller than the 30% advertised but worth picking up. Through-relay gain is muted because the qh3-only fraction of total CPU is smaller when a real relay is in the loop.

p99 latency rises with throughput in both cases (saturation queueing, not a qh3 regression).

## Plan

Don't bump the \`qh3>=\` pin in \`pyproject.toml\` until 1.8.0 actually releases on PyPI. This shim is the only change needed to be ready.

## Out of scope

- Rate-limited / multi-stream sweeps.
- Bump of the qh3 pin (defer until 1.8.0 ships).