### PR TITLE
ci: enhanced coverage — macOS matrix + multi-proc + cross-impl + interop label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[test]'
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cargo build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: moq-rs -> moq-rs/target
+          shared-key: moq-rs-d14
       - name: Generate self-signed cert
         run: |
           mkdir -p certs
@@ -151,55 +156,49 @@ jobs:
             -keyout certs/key.pem -out certs/cert.pem \
             -days 1 -subj "/CN=localhost" \
             -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
-      - name: Build + run cloudflare/moq-rs relay container
+      - name: Clone + build cloudflare/moq-rs (d14)
         run: |
-          # Build moq-rs from upstream main (d14). Long-running; cache
-          # if/when this proves valuable.
-          docker run -d --name moq-relay --network host \
-            -v "$PWD/certs:/certs" \
-            --entrypoint sh \
-            rust:1.85 -c '
-              git clone --depth=1 https://github.com/cloudflare/moq-rs /moq-rs &&
-              cd /moq-rs &&
-              cargo build --release --bin moq-relay-ietf &&
-              ./target/release/moq-relay-ietf \
-                --bind [::]:4443 \
-                --tls-cert /certs/cert.pem \
-                --tls-key /certs/key.pem \
-                --dev
-            ' &
-          # Wait for relay to be ready (best-effort).
-          for i in $(seq 1 90); do
-            sleep 2
-            if docker logs moq-relay 2>&1 | grep -q "listening on"; then
-              echo "relay up after ${i} iterations"
+          git clone --depth=1 https://github.com/cloudflare/moq-rs.git
+          cd moq-rs
+          cargo build --release --bin moq-relay-ietf --bin moq-clock-ietf
+      - name: Start relay + clock publisher
+        run: |
+          ./moq-rs/target/release/moq-relay-ietf \
+            --bind "[::]:4443" \
+            --tls-cert certs/cert.pem \
+            --tls-key certs/key.pem \
+            --dev > /tmp/relay.log 2>&1 &
+          # Wait for relay to be ready.
+          for i in $(seq 1 30); do
+            sleep 1
+            if grep -q "listening on" /tmp/relay.log 2>/dev/null; then
+              echo "relay up after ${i}s"
               break
             fi
           done
+          ./moq-rs/target/release/moq-clock-ietf --tls-disable-verify \
+            --publish --namespace clock --track now \
+            https://localhost:4443 > /tmp/clock-pub.log 2>&1 &
+          sleep 2
       - name: aiomoqt sub_bench against moq-rs relay (clock track)
         timeout-minutes: 3
         run: |
-          # moq-clock-ietf as publisher in the relay container
-          docker exec moq-relay sh -c '
-            cd /moq-rs &&
-            ./target/release/moq-clock-ietf --tls-disable-verify \
-              --publish --namespace clock --track now \
-              https://localhost:4443 > /tmp/clock-pub.log 2>&1 &
-          '
-          sleep 2
-          # aiomoqt subscriber
           timeout 12 python -m aiomoqt.examples.sub_bench \
             -n clock --trackname now --draft 14 -k -t 8 \
             https://localhost:4443 \
             > /tmp/sub.log 2>&1 || true
           echo === sub.log ===
           tail -25 /tmp/sub.log
+          echo === relay.log ===
+          tail -10 /tmp/relay.log
           # Require at least 5 clock objects (1 Hz publish rate).
           grep -E "Objects: *[0-9]+" /tmp/sub.log | tail -1 \
             | awk '{n=$2+0; if (n < 5) {print "FAIL: only " n " clock objs"; exit 1} else {print "OK: " n " clock objs"}}'
-      - name: Cleanup relay container
+      - name: Cleanup
         if: always()
-        run: docker rm -f moq-relay 2>/dev/null || true
+        run: |
+          pkill -f moq-relay-ietf 2>/dev/null || true
+          pkill -f moq-clock-ietf 2>/dev/null || true
 
   perf-gate:
     name: perf gate (parser microbench)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,20 @@ name: CI
 # integration tiers across supported Python versions. No publish /
 # release jobs — release.yml is manually dispatched from the Actions
 # tab when a release is ready to cut.
+#
+# Tiers (post-enhancement):
+#   - core: unit + integration via release_regression_test.py. Required
+#     on (linux, macos) x (3.12, 3.13, 3.14).
+#   - multi-proc: pub_server in one process, sub_bench in another.
+#     Catches Phase-7 backpressure / control-stream parser regressions
+#     that single-process loopback masks. continue-on-error initially.
+#   - cross-impl: aiomoqt sub_bench against cloudflare/moq-rs draft-14
+#     relay running in a Docker container. continue-on-error initially.
+#   - perf-gate: parser microbench short window. continue-on-error
+#     initially.
+#
+# The interop tier (live external relays) stays in interop-regression.yml
+# but gains a PR-label trigger there so contributors can opt-in.
 
 on:
   pull_request:
@@ -11,37 +25,197 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  core:
+    name: core / ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[test]'
-    - name: Generate self-signed cert for loopback
-      run: |
-        mkdir -p certs
-        openssl req -x509 -newkey rsa:2048 -nodes \
-          -keyout certs/key.pem -out certs/cert.pem \
-          -days 1 -subj "/CN=localhost"
-    - name: Run unit + integration tiers
-      run: |
-        python tests/release_regression_test.py \
-          --test-tier unit --test-tier integration
-    - name: Upload logs on failure
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: regression-logs-py${{ matrix.python-version }}
-        path: /tmp/aiomoqt-regression.*/
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[test]'
+      - name: Generate self-signed cert for loopback
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout certs/key.pem -out certs/cert.pem \
+            -days 1 -subj "/CN=localhost"
+      - name: Run unit + integration tiers
+        run: |
+          python tests/release_regression_test.py \
+            --test-tier unit --test-tier integration
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-logs-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: /tmp/aiomoqt-regression.*/
+
+  multi-proc:
+    name: multi-process pub_server / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[test]'
+      - name: Generate self-signed cert
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout certs/key.pem -out certs/cert.pem \
+            -days 1 -subj "/CN=localhost"
+      - name: pub_server <-> sub_bench loopback smoke (raw QUIC)
+        timeout-minutes: 4
+        run: |
+          # Spawn pub_server in background, run sub_bench against it.
+          # Asserts at least some object delivery in a 12 s window.
+          # Catches Phase-7 backpressure / TX-ring-fill stalls that
+          # in-process loopback doesn't exercise.
+          python -m aiomoqt.examples.pub_server \
+            --cert certs/cert.pem --key certs/key.pem \
+            -p 4434 -s 4096 -g 10000 -P 1 \
+            --draft 16 --quic > /tmp/pub-srv.log 2>&1 &
+          PUB_PID=$!
+          sleep 1.5
+          timeout 14 python -m aiomoqt.examples.sub_bench \
+            -Q --draft 16 -n bench --trackname track \
+            -t 12 -i 5 moqt://localhost:4434 \
+            > /tmp/sub.log 2>&1 || true
+          kill $PUB_PID 2>/dev/null || true
+          echo === sub.log ===
+          tail -30 /tmp/sub.log
+          echo === pub-srv.log ===
+          tail -20 /tmp/pub-srv.log
+          # Require at least 1000 objects delivered in 12 s.
+          # Conservative floor; the actual rate target is much higher.
+          grep -E "Objects: *[0-9]+" /tmp/sub.log | tail -1 \
+            | awk '{n=$2+0; if (n < 1000) {print "FAIL: only " n " objects"; exit 1} else {print "OK: " n " objects"}}'
+
+  cross-impl:
+    name: cross-impl interop (cloudflare/moq-rs d14)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[test]'
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+      - name: Generate self-signed cert
+        run: |
+          mkdir -p certs
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout certs/key.pem -out certs/cert.pem \
+            -days 1 -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+      - name: Build + run cloudflare/moq-rs relay container
+        run: |
+          # Build moq-rs from upstream main (d14). Long-running; cache
+          # if/when this proves valuable.
+          docker run -d --name moq-relay --network host \
+            -v "$PWD/certs:/certs" \
+            --entrypoint sh \
+            rust:1.85 -c '
+              git clone --depth=1 https://github.com/cloudflare/moq-rs /moq-rs &&
+              cd /moq-rs &&
+              cargo build --release --bin moq-relay-ietf &&
+              ./target/release/moq-relay-ietf \
+                --bind [::]:4443 \
+                --tls-cert /certs/cert.pem \
+                --tls-key /certs/key.pem \
+                --dev
+            ' &
+          # Wait for relay to be ready (best-effort).
+          for i in $(seq 1 90); do
+            sleep 2
+            if docker logs moq-relay 2>&1 | grep -q "listening on"; then
+              echo "relay up after ${i} iterations"
+              break
+            fi
+          done
+      - name: aiomoqt sub_bench against moq-rs relay (clock track)
+        timeout-minutes: 3
+        run: |
+          # moq-clock-ietf as publisher in the relay container
+          docker exec moq-relay sh -c '
+            cd /moq-rs &&
+            ./target/release/moq-clock-ietf --tls-disable-verify \
+              --publish --namespace clock --track now \
+              https://localhost:4443 > /tmp/clock-pub.log 2>&1 &
+          '
+          sleep 2
+          # aiomoqt subscriber
+          timeout 12 python -m aiomoqt.examples.sub_bench \
+            -n clock --trackname now --draft 14 -k -t 8 \
+            https://localhost:4443 \
+            > /tmp/sub.log 2>&1 || true
+          echo === sub.log ===
+          tail -25 /tmp/sub.log
+          # Require at least 5 clock objects (1 Hz publish rate).
+          grep -E "Objects: *[0-9]+" /tmp/sub.log | tail -1 \
+            | awk '{n=$2+0; if (n < 5) {print "FAIL: only " n " clock objs"; exit 1} else {print "OK: " n " clock objs"}}'
+      - name: Cleanup relay container
+        if: always()
+        run: docker rm -f moq-relay 2>/dev/null || true
+
+  perf-gate:
+    name: perf gate (parser microbench)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[test]'
+      - name: Run parser microbench
+        timeout-minutes: 5
+        run: |
+          # b1_parser is parser-only, no transport; reliable on
+          # hosted runners. Floor enforcement deferred until we have
+          # a few runs to calibrate runner noise.
+          python -m aiomoqt.tests.microbench.b1_parser \
+            --duration 3 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,8 @@ jobs:
             -days 1 -subj "/CN=localhost"
       - name: Run unit + integration tiers
         run: |
-          # --integration-parallel 4: loopback variants use distinct
-          # ports and run concurrently in a ThreadPoolExecutor. Cuts
-          # integration tier wall time ~3x (slowest suite is the floor).
           python tests/release_regression_test.py \
-            --test-tier unit --test-tier integration \
-            --integration-parallel 4
+            --test-tier unit --test-tier integration
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,12 @@ jobs:
             -days 1 -subj "/CN=localhost"
       - name: Run unit + integration tiers
         run: |
+          # --integration-parallel 4: loopback variants use distinct
+          # ports and run concurrently in a ThreadPoolExecutor. Cuts
+          # integration tier wall time ~3x (slowest suite is the floor).
           python tests/release_regression_test.py \
-            --test-tier unit --test-tier integration
+            --test-tier unit --test-tier integration \
+            --integration-parallel 4
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
           grep -E "Objects: *[0-9]+" /tmp/sub.log | tail -1 \
             | awk '{n=$2+0; if (n < 1000) {print "FAIL: only " n " objects"; exit 1} else {print "OK: " n " objects"}}'
 
-  cross-impl:
-    name: cross-impl interop (cloudflare/moq-rs d14)
+  peer-interop:
+    name: peer interop
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -200,8 +200,8 @@ jobs:
           pkill -f moq-relay-ietf 2>/dev/null || true
           pkill -f moq-clock-ietf 2>/dev/null || true
 
-  perf-gate:
-    name: perf gate (parser microbench)
+  benchmark:
+    name: benchmark
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -83,6 +85,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -132,6 +136,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -207,6 +213,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.14"
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/interop-regression.yml
+++ b/.github/workflows/interop-regression.yml
@@ -12,9 +12,19 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '17 3 * * 1'    # Mondays 03:17 UTC
+  # PR opt-in: contributors add the `ci:run-interop` label when their
+  # change touches wire-format or session-protocol code. Avoids burning
+  # the weekly slot AND avoids hitting public relays on every doc PR.
+  pull_request:
+    types: [labeled, synchronize]
 
 jobs:
   interop:
+    # Skip on label-PR runs unless the label is actually present.
+    # For workflow_dispatch + schedule there's no label gate.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:run-interop')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/tests/release_regression_test.py
+++ b/tests/release_regression_test.py
@@ -161,26 +161,17 @@ def _loopback_setup(log_dir: Path) -> tuple[str, str]:
                         log_dir / "loopback-setup.log")
 
 
-def _loopback_pub_sub(log_dir: Path) -> tuple[str, str]:
-    log = log_dir / "loopback-pub-sub.log"
-    cmd = [
-        "python", "-m", "aiomoqt.examples.loopback_bench",
-        "-P", "4", "-s", "16384", "-r", "60", "-t", "10",
-    ]
-    ok, _ = _run(cmd, log, 40)
-    text = log.read_text()
-    m = re.search(r"Throughput:\s+([\d.]+)\s*Mbps", text)
-    no_loss = "Lost:        0 (0.00%)" in text
-    tput = m.group(1) if m else "?"
-    return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
-
-
 def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
-                                timeout: int) -> tuple[str, str]:
-    """Generic runner for loopback_bench variants."""
+                              timeout: int, port: int) -> tuple[str, str]:
+    """Generic runner for loopback_bench variants.
+
+    port is passed via -p so multiple variants can run concurrently
+    without port collisions (see --integration-parallel).
+    """
     log = log_dir / f"{slug}.log"
     cmd = [
         "python", "-m", "aiomoqt.examples.loopback_bench",
+        "-p", str(port),
         *flags,
     ]
     ok, _ = _run(cmd, log, timeout)
@@ -191,13 +182,22 @@ def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
     return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
 
 
+def _loopback_pub_sub(log_dir: Path) -> tuple[str, str]:
+    # Baseline: mid-size, mid-rate, paced. ~31 Mbps.
+    return _loopback_pub_sub_variant(
+        log_dir, "loopback-pub-sub",
+        ["-P", "4", "-s", "16384", "-r", "60", "-t", "10"],
+        timeout=40, port=4434,
+    )
+
+
 def _loopback_pub_sub_tiny(log_dir: Path) -> tuple[str, str]:
     # Tiny objects at high obj/s — stresses per-object Python overhead,
     # parser/framer hot path. Target rate ~4 Mbps.
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-tiny",
         ["-P", "1", "-s", "64", "-r", "8000", "-g", "1000", "-t", "5"],
-        timeout=30,
+        timeout=30, port=4435,
     )
 
 
@@ -209,7 +209,7 @@ def _loopback_pub_sub_streams(log_dir: Path) -> tuple[str, str]:
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-streams",
         ["-P", "4", "-s", "256", "-r", "2000", "-g", "100", "-t", "5"],
-        timeout=30,
+        timeout=30, port=4436,
     )
 
 
@@ -220,8 +220,21 @@ def _loopback_pub_sub_paced(log_dir: Path) -> tuple[str, str]:
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-paced",
         ["-P", "4", "-s", "8192", "-r", "800", "-g", "5000", "-t", "8"],
-        timeout=40,
+        timeout=40, port=4437,
     )
+
+
+# Suite-name -> (runner_func, log_basename). Drives both sequential
+# and parallel integration-tier dispatch.
+INTEGRATION_DISPATCH = {
+    "loopback-setup":           (_loopback_setup,           "loopback-setup.log"),
+    "loopback-pub-sub":         (_loopback_pub_sub,         "loopback-pub-sub.log"),
+    "loopback-pub-sub-tiny":    (_loopback_pub_sub_tiny,    "loopback-pub-sub-tiny.log"),
+    "loopback-pub-sub-streams": (_loopback_pub_sub_streams, "loopback-pub-sub-streams.log"),
+    "loopback-pub-sub-paced":   (_loopback_pub_sub_paced,   "loopback-pub-sub-paced.log"),
+    "loopback-join":            (_loopback_join,            "loopback-join.log"),
+    "loopback-fetch":           (_loopback_fetch,           "loopback-fetch.log"),
+}
 
 
 def _loopback_join(log_dir: Path) -> tuple[str, str]:
@@ -420,6 +433,11 @@ def main() -> int:
     ap.add_argument("--interop-parallel", type=int, default=4,
                     metavar="N", help="relays to run concurrently in the "
                                       "interop tier (default: 4)")
+    ap.add_argument("--integration-parallel", type=int, default=1,
+                    metavar="N", help="loopback suites to run "
+                                      "concurrently in the integration "
+                                      "tier (default: 1 = sequential; "
+                                      "set 4 in CI for ~3x wall speedup)")
     args = ap.parse_args()
 
     if args.test_tiers or args.test_suites:
@@ -474,34 +492,30 @@ def main() -> int:
     # --- integration tier ---
     if enabled & set(TIERS["integration"]):
         print("\n== integration ==")
-        if "loopback-setup" in enabled:
-            status, detail = _loopback_setup(log_dir)
-            record_and_print((status, "loopback-setup", detail,
-                              log_dir / "loopback-setup.log"))
-        if "loopback-pub-sub" in enabled:
-            status, detail = _loopback_pub_sub(log_dir)
-            record_and_print((status, "loopback-pub-sub", detail,
-                              log_dir / "loopback-pub-sub.log"))
-        if "loopback-pub-sub-tiny" in enabled:
-            status, detail = _loopback_pub_sub_tiny(log_dir)
-            record_and_print((status, "loopback-pub-sub-tiny", detail,
-                              log_dir / "loopback-pub-sub-tiny.log"))
-        if "loopback-pub-sub-streams" in enabled:
-            status, detail = _loopback_pub_sub_streams(log_dir)
-            record_and_print((status, "loopback-pub-sub-streams", detail,
-                              log_dir / "loopback-pub-sub-streams.log"))
-        if "loopback-pub-sub-paced" in enabled:
-            status, detail = _loopback_pub_sub_paced(log_dir)
-            record_and_print((status, "loopback-pub-sub-paced", detail,
-                              log_dir / "loopback-pub-sub-paced.log"))
-        if "loopback-join" in enabled:
-            status, detail = _loopback_join(log_dir)
-            record_and_print((status, "loopback-join", detail,
-                              log_dir / "loopback-join.log"))
-        if "loopback-fetch" in enabled:
-            status, detail = _loopback_fetch(log_dir)
-            record_and_print((status, "loopback-fetch", detail,
-                              log_dir / "loopback-fetch.log"))
+        integ_suites = [s for s in TIERS["integration"] if s in enabled]
+        workers = max(1, args.integration_parallel)
+        if workers == 1 or len(integ_suites) <= 1:
+            # Sequential — preserves prior behavior + ordering.
+            for name in integ_suites:
+                func, log_name = INTEGRATION_DISPATCH[name]
+                status, detail = func(log_dir)
+                record_and_print((status, name, detail,
+                                  log_dir / log_name))
+        else:
+            # Parallel — distinct ports per loopback variant let the
+            # variants run concurrently without bind collisions.
+            with concurrent.futures.ThreadPoolExecutor(
+                    max_workers=workers) as ex:
+                futures = {
+                    ex.submit(INTEGRATION_DISPATCH[name][0], log_dir): name
+                    for name in integ_suites
+                }
+                for fut in concurrent.futures.as_completed(futures):
+                    name = futures[fut]
+                    _, log_name = INTEGRATION_DISPATCH[name]
+                    status, detail = fut.result()
+                    record_and_print((status, name, detail,
+                                      log_dir / log_name))
 
     # --- interop tier (parallel per relay) ---
     # Per-suite progress prints live from worker threads via _progress().

--- a/tests/release_regression_test.py
+++ b/tests/release_regression_test.py
@@ -161,17 +161,26 @@ def _loopback_setup(log_dir: Path) -> tuple[str, str]:
                         log_dir / "loopback-setup.log")
 
 
-def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
-                              timeout: int, port: int) -> tuple[str, str]:
-    """Generic runner for loopback_bench variants.
+def _loopback_pub_sub(log_dir: Path) -> tuple[str, str]:
+    log = log_dir / "loopback-pub-sub.log"
+    cmd = [
+        "python", "-m", "aiomoqt.examples.loopback_bench",
+        "-P", "4", "-s", "16384", "-r", "60", "-t", "10",
+    ]
+    ok, _ = _run(cmd, log, 40)
+    text = log.read_text()
+    m = re.search(r"Throughput:\s+([\d.]+)\s*Mbps", text)
+    no_loss = "Lost:        0 (0.00%)" in text
+    tput = m.group(1) if m else "?"
+    return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
 
-    port is passed via -p so multiple variants can run concurrently
-    without port collisions (see --integration-parallel).
-    """
+
+def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
+                                timeout: int) -> tuple[str, str]:
+    """Generic runner for loopback_bench variants."""
     log = log_dir / f"{slug}.log"
     cmd = [
         "python", "-m", "aiomoqt.examples.loopback_bench",
-        "-p", str(port),
         *flags,
     ]
     ok, _ = _run(cmd, log, timeout)
@@ -182,22 +191,13 @@ def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
     return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
 
 
-def _loopback_pub_sub(log_dir: Path) -> tuple[str, str]:
-    # Baseline: mid-size, mid-rate, paced. ~31 Mbps.
-    return _loopback_pub_sub_variant(
-        log_dir, "loopback-pub-sub",
-        ["-P", "4", "-s", "16384", "-r", "60", "-t", "10"],
-        timeout=40, port=4434,
-    )
-
-
 def _loopback_pub_sub_tiny(log_dir: Path) -> tuple[str, str]:
     # Tiny objects at high obj/s — stresses per-object Python overhead,
     # parser/framer hot path. Target rate ~4 Mbps.
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-tiny",
         ["-P", "1", "-s", "64", "-r", "8000", "-g", "1000", "-t", "5"],
-        timeout=30, port=4435,
+        timeout=30,
     )
 
 
@@ -209,7 +209,7 @@ def _loopback_pub_sub_streams(log_dir: Path) -> tuple[str, str]:
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-streams",
         ["-P", "4", "-s", "256", "-r", "2000", "-g", "100", "-t", "5"],
-        timeout=30, port=4436,
+        timeout=30,
     )
 
 
@@ -220,21 +220,8 @@ def _loopback_pub_sub_paced(log_dir: Path) -> tuple[str, str]:
     return _loopback_pub_sub_variant(
         log_dir, "loopback-pub-sub-paced",
         ["-P", "4", "-s", "8192", "-r", "800", "-g", "5000", "-t", "8"],
-        timeout=40, port=4437,
+        timeout=40,
     )
-
-
-# Suite-name -> (runner_func, log_basename). Drives both sequential
-# and parallel integration-tier dispatch.
-INTEGRATION_DISPATCH = {
-    "loopback-setup":           (_loopback_setup,           "loopback-setup.log"),
-    "loopback-pub-sub":         (_loopback_pub_sub,         "loopback-pub-sub.log"),
-    "loopback-pub-sub-tiny":    (_loopback_pub_sub_tiny,    "loopback-pub-sub-tiny.log"),
-    "loopback-pub-sub-streams": (_loopback_pub_sub_streams, "loopback-pub-sub-streams.log"),
-    "loopback-pub-sub-paced":   (_loopback_pub_sub_paced,   "loopback-pub-sub-paced.log"),
-    "loopback-join":            (_loopback_join,            "loopback-join.log"),
-    "loopback-fetch":           (_loopback_fetch,           "loopback-fetch.log"),
-}
 
 
 def _loopback_join(log_dir: Path) -> tuple[str, str]:
@@ -433,11 +420,6 @@ def main() -> int:
     ap.add_argument("--interop-parallel", type=int, default=4,
                     metavar="N", help="relays to run concurrently in the "
                                       "interop tier (default: 4)")
-    ap.add_argument("--integration-parallel", type=int, default=1,
-                    metavar="N", help="loopback suites to run "
-                                      "concurrently in the integration "
-                                      "tier (default: 1 = sequential; "
-                                      "set 4 in CI for ~3x wall speedup)")
     args = ap.parse_args()
 
     if args.test_tiers or args.test_suites:
@@ -492,30 +474,34 @@ def main() -> int:
     # --- integration tier ---
     if enabled & set(TIERS["integration"]):
         print("\n== integration ==")
-        integ_suites = [s for s in TIERS["integration"] if s in enabled]
-        workers = max(1, args.integration_parallel)
-        if workers == 1 or len(integ_suites) <= 1:
-            # Sequential — preserves prior behavior + ordering.
-            for name in integ_suites:
-                func, log_name = INTEGRATION_DISPATCH[name]
-                status, detail = func(log_dir)
-                record_and_print((status, name, detail,
-                                  log_dir / log_name))
-        else:
-            # Parallel — distinct ports per loopback variant let the
-            # variants run concurrently without bind collisions.
-            with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=workers) as ex:
-                futures = {
-                    ex.submit(INTEGRATION_DISPATCH[name][0], log_dir): name
-                    for name in integ_suites
-                }
-                for fut in concurrent.futures.as_completed(futures):
-                    name = futures[fut]
-                    _, log_name = INTEGRATION_DISPATCH[name]
-                    status, detail = fut.result()
-                    record_and_print((status, name, detail,
-                                      log_dir / log_name))
+        if "loopback-setup" in enabled:
+            status, detail = _loopback_setup(log_dir)
+            record_and_print((status, "loopback-setup", detail,
+                              log_dir / "loopback-setup.log"))
+        if "loopback-pub-sub" in enabled:
+            status, detail = _loopback_pub_sub(log_dir)
+            record_and_print((status, "loopback-pub-sub", detail,
+                              log_dir / "loopback-pub-sub.log"))
+        if "loopback-pub-sub-tiny" in enabled:
+            status, detail = _loopback_pub_sub_tiny(log_dir)
+            record_and_print((status, "loopback-pub-sub-tiny", detail,
+                              log_dir / "loopback-pub-sub-tiny.log"))
+        if "loopback-pub-sub-streams" in enabled:
+            status, detail = _loopback_pub_sub_streams(log_dir)
+            record_and_print((status, "loopback-pub-sub-streams", detail,
+                              log_dir / "loopback-pub-sub-streams.log"))
+        if "loopback-pub-sub-paced" in enabled:
+            status, detail = _loopback_pub_sub_paced(log_dir)
+            record_and_print((status, "loopback-pub-sub-paced", detail,
+                              log_dir / "loopback-pub-sub-paced.log"))
+        if "loopback-join" in enabled:
+            status, detail = _loopback_join(log_dir)
+            record_and_print((status, "loopback-join", detail,
+                              log_dir / "loopback-join.log"))
+        if "loopback-fetch" in enabled:
+            status, detail = _loopback_fetch(log_dir)
+            record_and_print((status, "loopback-fetch", detail,
+                              log_dir / "loopback-fetch.log"))
 
     # --- interop tier (parallel per relay) ---
     # Per-suite progress prints live from worker threads via _progress().

--- a/tests/release_regression_test.py
+++ b/tests/release_regression_test.py
@@ -47,6 +47,9 @@ DEFAULT_CATALOG = Path(__file__).parent / "relays.json"
 TIERS = {
     "unit":        ["buffer", "message", "track"],
     "integration": ["loopback-setup", "loopback-pub-sub",
+                    "loopback-pub-sub-tiny",
+                    "loopback-pub-sub-streams",
+                    "loopback-pub-sub-paced",
                     "loopback-join", "loopback-fetch"],
     "interop":     ["relay-ctrl-msg", "relay-pub-sub",
                     "relay-join", "relay-fetch"],
@@ -170,6 +173,55 @@ def _loopback_pub_sub(log_dir: Path) -> tuple[str, str]:
     no_loss = "Lost:        0 (0.00%)" in text
     tput = m.group(1) if m else "?"
     return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
+
+
+def _loopback_pub_sub_variant(log_dir: Path, slug: str, flags: list[str],
+                                timeout: int) -> tuple[str, str]:
+    """Generic runner for loopback_bench variants."""
+    log = log_dir / f"{slug}.log"
+    cmd = [
+        "python", "-m", "aiomoqt.examples.loopback_bench",
+        *flags,
+    ]
+    ok, _ = _run(cmd, log, timeout)
+    text = log.read_text()
+    m = re.search(r"Throughput:\s+([\d.]+)\s*Mbps", text)
+    no_loss = "Lost:        0 (0.00%)" in text
+    tput = m.group(1) if m else "?"
+    return ("PASS" if ok and no_loss else "FAIL"), f"{tput} Mbps"
+
+
+def _loopback_pub_sub_tiny(log_dir: Path) -> tuple[str, str]:
+    # Tiny objects at high obj/s — stresses per-object Python overhead,
+    # parser/framer hot path. Target rate ~4 Mbps.
+    return _loopback_pub_sub_variant(
+        log_dir, "loopback-pub-sub-tiny",
+        ["-P", "1", "-s", "64", "-r", "8000", "-g", "1000", "-t", "5"],
+        timeout=30,
+    )
+
+
+def _loopback_pub_sub_streams(log_dir: Path) -> tuple[str, str]:
+    # High stream churn: 4 streams × 2000 obj/s with group_size=100
+    # means a new stream every ~50 ms (~400 stream lifecycles over the
+    # run). Stresses stream-open / per-stream byte ring / cleanup.
+    # Target rate ~16 Mbps.
+    return _loopback_pub_sub_variant(
+        log_dir, "loopback-pub-sub-streams",
+        ["-P", "4", "-s", "256", "-r", "2000", "-g", "100", "-t", "5"],
+        timeout=30,
+    )
+
+
+def _loopback_pub_sub_paced(log_dir: Path) -> tuple[str, str]:
+    # Paced high-BW (not saturating): 4 streams × 800 obj/s × 8 KiB =
+    # ~205 Mbps target. Tests flow control + pacer behavior at a real
+    # video-class rate without hitting saturation.
+    return _loopback_pub_sub_variant(
+        log_dir, "loopback-pub-sub-paced",
+        ["-P", "4", "-s", "8192", "-r", "800", "-g", "5000", "-t", "8"],
+        timeout=40,
+    )
 
 
 def _loopback_join(log_dir: Path) -> tuple[str, str]:
@@ -430,6 +482,18 @@ def main() -> int:
             status, detail = _loopback_pub_sub(log_dir)
             record_and_print((status, "loopback-pub-sub", detail,
                               log_dir / "loopback-pub-sub.log"))
+        if "loopback-pub-sub-tiny" in enabled:
+            status, detail = _loopback_pub_sub_tiny(log_dir)
+            record_and_print((status, "loopback-pub-sub-tiny", detail,
+                              log_dir / "loopback-pub-sub-tiny.log"))
+        if "loopback-pub-sub-streams" in enabled:
+            status, detail = _loopback_pub_sub_streams(log_dir)
+            record_and_print((status, "loopback-pub-sub-streams", detail,
+                              log_dir / "loopback-pub-sub-streams.log"))
+        if "loopback-pub-sub-paced" in enabled:
+            status, detail = _loopback_pub_sub_paced(log_dir)
+            record_and_print((status, "loopback-pub-sub-paced", detail,
+                              log_dir / "loopback-pub-sub-paced.log"))
         if "loopback-join" in enabled:
             status, detail = _loopback_join(log_dir)
             record_and_print((status, "loopback-join", detail,


### PR DESCRIPTION
## Summary

Restructures `ci.yml` into four tiered jobs + adds opt-in PR trigger to `interop-regression.yml`.

- **core** (required): unit + integration via `release_regression_test.py`. Adds `[macos-latest]` to existing Python matrix → 6 required combos.
- **multi-proc** (continue-on-error): `pub_server` subprocess + `sub_bench`, asserts > 1000 objects in 12 s. Catches Phase-7 backpressure / TX-ring-fill stalls and control-stream parser bugs that single-process loopback masks.
- **cross-impl** (continue-on-error): containerized `cloudflare/moq-rs` d14 relay + `moq-clock-ietf` publisher + aiomoqt `sub_bench`. PR-time interop coverage without depending on public relay availability.
- **perf-gate** (continue-on-error): `b1_parser` microbench, no transport. Floor enforcement deferred until noise is calibrated.

`interop-regression.yml`: adds opt-in `pull_request` trigger gated on the `ci:run-interop` label. Contributors apply the label for wire-format / session-protocol PRs; doc-only PRs skip the public relay hit. Cron + workflow_dispatch behavior unchanged.

## Why now

The current release cycle surfaced macOS-specific bugs (off-payload-read in `_extensions_decode`, picoquic_close UAF on teardown) that would have shipped green under the prior linux-only matrix. Multi-process and cross-impl coverage gaps allowed regressions in the Phase-7 backpressure path and wire-format roundtrips to not show up on PR.

## Test plan
- [ ] core tier passes on all 6 matrix combos
- [ ] multi-proc tier — observe failures (the recently-fixed TX-ring-fill stall is the bug this catches)
- [ ] cross-impl tier — observe Docker build time / cache potential
- [ ] perf-gate — observe runner noise; floor enforcement comes in follow-up PR
- [ ] interop-regression label gate — verify PRs without the label skip the job; PRs with the label run it

🤖 Generated with [Claude Code](https://claude.com/claude-code)