### PR TITLE
perf-0.9.5: pressure-based yield in stream_write_drain

### DIFF
--- a/.github/actions/setup-aiomoqt/action.yml
+++ b/.github/actions/setup-aiomoqt/action.yml
@@ -1,0 +1,36 @@
+name: 'Set up aiomoqt env'
+description: >
+  Set up Python with pip cache, then install aiomoqt in editable mode
+  with the requested extras. Centralizes the env-setup dance that
+  every CI job in this repo would otherwise repeat.
+
+inputs:
+  python-version:
+    description: 'Python version to install (e.g. "3.14", "3.13", "3.12")'
+    required: false
+    default: '3.14'
+  extras:
+    description: >
+      Pip install extras key (e.g. "test" → installs ".[test]").
+      Use "" to install with no extras.
+    required: false
+    default: 'test'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
+    - name: Install aiomoqt (editable)
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        if [ -n "${{ inputs.extras }}" ]; then
+          pip install -e ".[${{ inputs.extras }}]"
+        else
+          pip install -e .
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,13 +121,26 @@ jobs:
             kill $PUB_PID 2>/dev/null || true
             exit 1
           fi
-          # sub_bench self-times out via -t 12; don't wrap with the
-          # external `timeout` binary (macOS lacks it by default and
-          # would silently skip the run, producing a false-pass).
-          python -m aiomoqt.examples.sub_bench \
+          # sub_bench's -t timeout doesn't reliably fire (track.
+          # wait_closed timeout=12 keeps running into bufferbloat at
+          # this rate). Wrap with a bash watchdog so the step always
+          # captures sub.log before the runner SIGTERMs us — bounded
+          # cleanup + visible failure mode. The underlying sub_bench
+          # -t bug is tracked for 0.9.6.
+          python -u -m aiomoqt.examples.sub_bench \
             -Q --draft 16 -n bench --trackname track \
             -t 12 -i 5 moqt://localhost:4434 \
-            > /tmp/sub.log 2>&1 || true
+            > /tmp/sub.log 2>&1 &
+          SUB_PID=$!
+          # Up to 20s (12s -t + 8s slack), then force-kill.
+          for i in $(seq 1 40); do
+            if ! kill -0 $SUB_PID 2>/dev/null; then break; fi
+            sleep 0.5
+          done
+          kill $SUB_PID 2>/dev/null || true
+          sleep 0.5
+          kill -9 $SUB_PID 2>/dev/null || true
+          wait $SUB_PID 2>/dev/null || true
           kill $PUB_PID 2>/dev/null || true
           echo === sub.log ===
           tail -30 /tmp/sub.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Opt every job + every third-party action into the Node 24 runtime
+# ahead of GitHub's 2026-06-02 hard cutover (Node 20 removed entirely
+# 2026-09-16). One env beats per-action version cherry-picking and
+# covers actions that haven't shipped a Node-24 release yet.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   core:
     name: core / ${{ matrix.os }} / py${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
           # Asserts at least some object delivery in a 12 s window.
           # Catches Phase-7 backpressure / TX-ring-fill stalls that
           # in-process loopback doesn't exercise.
-          python -m aiomoqt.examples.pub_server \
+          # -u so the "ready on" banner reaches /tmp/pub-srv.log
+          # before our poll grep runs (Python buffers stdout in 4KB
+          # chunks when redirected to a file).
+          python -u -m aiomoqt.examples.pub_server \
             --cert certs/cert.pem --key certs/key.pem \
             -p 4434 -s 4096 -g 10000 -P 1 \
             --draft 16 --quic > /tmp/pub-srv.log 2>&1 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-aiomoqt
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[test]'
       - name: Generate self-signed cert for loopback
         run: |
           mkdir -p certs
@@ -88,16 +81,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[test]'
+      - uses: ./.github/actions/setup-aiomoqt
       - name: Generate self-signed cert
         run: |
           mkdir -p certs
@@ -149,16 +133,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[test]'
+      - uses: ./.github/actions/setup-aiomoqt
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Cargo build cache
@@ -225,16 +200,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[test]'
+      - uses: ./.github/actions/setup-aiomoqt
       - name: Run parser microbench
         timeout-minutes: 5
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,17 +146,21 @@ jobs:
           tail -30 /tmp/sub.log
           echo === pub-srv.log ===
           tail -20 /tmp/pub-srv.log
-          # Require at least 100 objects delivered in 12 s. The path
-          # works when non-zero; threshold gives generous margin for
-          # variable CI runner perf. Fails loudly when no Objects line
-          # was emitted at all (sub_bench failed to start / connect).
-          LINE=$(grep -E "Objects: *[0-9]+" /tmp/sub.log | tail -1)
-          if [ -z "$LINE" ]; then
-            echo "FAIL: no 'Objects:' line in sub.log — sub_bench did not run"
+          # Assertion reads the per-interval table (always emitted even
+          # when watchdog kills sub_bench) instead of the "Objects:"
+          # summary block (only emitted on natural exit). Interval
+          # format: "  10-15s    65      642256    29330/s   964Mbps ..."
+          # — column 3 is the cumulative obj count.
+          LAST_OBJS=$(grep -oE '^[[:space:]]+[0-9]+-[0-9]+s[[:space:]]+[0-9]+[[:space:]]+[0-9]+' /tmp/sub.log | tail -1 | awk '{print $3}')
+          if [ -z "$LAST_OBJS" ]; then
+            echo "FAIL: no interval data in sub.log — sub_bench did not run"
             exit 1
           fi
-          echo "$LINE" \
-            | awk '{n=$2+0; if (n < 100) {print "FAIL: only " n " objects"; exit 1} else {print "OK: " n " objects"}}'
+          if [ "$LAST_OBJS" -lt 100 ]; then
+            echo "FAIL: only $LAST_OBJS objects"
+            exit 1
+          fi
+          echo "OK: $LAST_OBJS objects in last interval"
 
   peer-interop:
     name: peer interop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,24 @@ jobs:
             -p 4434 -s 4096 -g 10000 -P 1 \
             --draft 16 --quic > /tmp/pub-srv.log 2>&1 &
           PUB_PID=$!
-          sleep 1.5
+          # Poll up to 10s for pub_server's "ready on" line. Bare
+          # `sleep 1.5` was flaky on busier Linux runners — pub_server
+          # not yet bound at 1.5s leads to sub_bench connect failure
+          # which then hangs in await track.subscribe() (no upper
+          # time bound there, -t only applies post-subscribe).
+          for i in $(seq 1 20); do
+            if grep -q "ready on" /tmp/pub-srv.log 2>/dev/null; then
+              echo "pub_server ready after $((i*500))ms"
+              break
+            fi
+            sleep 0.5
+          done
+          if ! grep -q "ready on" /tmp/pub-srv.log 2>/dev/null; then
+            echo "FAIL: pub_server not ready in 10s"
+            tail -20 /tmp/pub-srv.log
+            kill $PUB_PID 2>/dev/null || true
+            exit 1
+          fi
           # sub_bench self-times out via -t 12; don't wrap with the
           # external `timeout` binary (macOS lacks it by default and
           # would silently skip the run, producing a false-pass).

--- a/.github/workflows/interop-regression.yml
+++ b/.github/workflows/interop-regression.yml
@@ -39,15 +39,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.14"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install -e .
+    - uses: ./.github/actions/setup-aiomoqt
     - name: Run interop-tier regression
       run: python tests/release_regression_test.py --test-tier interop
     - name: Upload logs on failure

--- a/.github/workflows/interop-regression.yml
+++ b/.github/workflows/interop-regression.yml
@@ -20,6 +20,13 @@ on:
   pull_request:
     types: [labeled]
 
+# Opt every job + every third-party action into the Node 24 runtime
+# ahead of GitHub's 2026-06-02 hard cutover (Node 20 removed entirely
+# 2026-09-16). One env beats per-action version cherry-picking and
+# covers actions that haven't shipped a Node-24 release yet.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   interop:
     # Skip on label-PR runs unless the label is actually present.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ on:
         required: true
         type: string
 
+# Opt every job + every third-party action into the Node 24 runtime
+# ahead of GitHub's 2026-06-02 hard cutover (Node 20 removed entirely
+# 2026-09-16). One env beats per-action version cherry-picking and
+# covers actions that haven't shipped a Node-24 release yet.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,9 @@ jobs:
       with:
         ref: ${{ needs.tag.outputs.version }}
         fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: ./.github/actions/setup-aiomoqt
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[test]'
     - name: Generate self-signed cert for loopback
       run: |
         mkdir -p certs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,23 @@
 Pairs with [aiopquic 0.3.3](https://pypi.org/project/aiopquic/0.3.3/);
 dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.3`.
 
-### Publisher `r=0` yield heuristic — pressure-based
+### Pressure-based yield in `stream_write_drain`
 
 `PublishedTrack._generate_subgroup` previously yielded with
 `asyncio.sleep(0)` every 64 objects on the unbounded-rate (`-r 0`)
-path. On fast Python publish loops the count-based yield can starve
-the picoquic worker thread between yields, capping single-stream
-throughput well below the transport ceiling.
+path. On fast Python publish loops that count-based heuristic can
+starve the picoquic worker between yields, capping throughput well
+below the transport ceiling.
 
-Switch to `session._quic.tx_pressure(stream_id) > 0.5` as the yield
-trigger. The publisher releases the GIL whenever aiopquic reports
-its TX-ring is filling, regardless of how many objects have been
-sent. Bounded-rate (`-r N>0`) callers are unchanged — they pace via
-`asyncio.sleep(1/rate)` as before.
+`MOQTSession.stream_write_drain` now performs a soft pressure-based
+yield: after a successful (non-`BufferError`) write, it checks
+`tx_pressure(stream_id)` and `await asyncio.sleep(0)` if pressure
+exceeds 0.5. Every aiomoqt sender benefits — including third-party
+publishers that drive the API directly, not just `PublishedTrack`.
+
+The count-based `else: ... asyncio.sleep(0)` block in
+`_generate_subgroup` is removed; bounded-rate (`-r N>0`) callers pace
+via `asyncio.sleep(1/rate)` as before.
 
 ## v0.9.4 (2026-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,21 @@
 
 ## v0.9.5 (unreleased)
 
-Pairs with [aiopquic 0.3.3](https://pypi.org/project/aiopquic/0.3.3/);
-dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.3`.
+Pairs with [aiopquic 0.3.5](https://pypi.org/project/aiopquic/0.3.5/);
+dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.5`.
+
+### WT-server d16 draft pin
+
+`MOQTSessionWTServer.__init__` now calls `set_moqt_ctx_version(session.draft_version)` symmetrically with the raw-QUIC ALPN handler and the WT-client init path. Without it, the global `moqt_version` stayed at `MOQT_VERSION_DRAFT14` on the server, so `ClientSetup.deserialize` expected the d14 wire format (version list first) while a d16 client sent the d16 format (no version list) — observable as `BufferReadError` on the first incoming `ClientSetup`. Unblocks 2-proc WT d16; validated at 2.2-2.3 Gbps p99 75ms.
+
+### Observability
+
+- `--cc-algo` flag exposed on `MOQTServer` / `MOQTClient` and 11 example tools (`loopback_bench`, `pub_server`, `sub_bench`, `pub_bench`, `multi_sub_bench`, `adaptive_bench`, `relay_bench`, `pub_example`, `sub_example`, `server_example`, `join_example`). Passes through to `QuicConfiguration.congestion_control_algorithm`. Default BBR.
+- `python -m aiomoqt.versions` / `aiomoqt-versions` documented in README ("Reporting issues" section). Chains through `aiopquic.versions` for full stack: aiomoqt + aiopquic + picoquic + picotls.
+
+### Tooling
+
+- `[tool.ruff] line-length = 100` retained as the standard (aiopquic now matches).
 
 ### Pressure-based yield in `stream_write_drain`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 Pairs with [aiopquic 0.3.5](https://pypi.org/project/aiopquic/0.3.5/);
 dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.5`.
 
+### WT receiver bloat (RELEASE BLOCKER) — root cause + fix
+
+`_WTSessionMixin._on_event` in `protocol.py` previously called `super()._on_event(ev_tuple)` for every WT event, then re-dispatched stream/datagram events via `quic_event_received` for the MoQT data path. The `super()` call enqueued `_EVT_WT_STREAM_DATA` / `_EVT_WT_STREAM_FIN` / `_EVT_WT_DATAGRAM` events into per-stream `asyncio.Queue` instances inside `WebTransportSession._stream_inbox` — but aiomoqt never consumes those queues (it routes via the QuicEvent translation path instead). Every queued event held a reference to the `memoryview` payload, which in turn pinned the underlying `aiopquic` `StreamChunk` alive. At 2.5 Gbps the leak grew ~60K chunks/sec → 5–18 GB RSS within 30–60 s.
+
+Fix: skip `super()._on_event(ev_tuple)` for the event types we translate locally. Session-level events (ready / closed / draining / new_stream / tx_drained) still go through the base handler for their queue / Future signaling. After the fix: `chunks_alive_total` stays in single digits, RSS bounded, throughput unchanged (~2.3 Gbps), p99 latency drops from 384 ms (cliff) to 39 ms. Verified at 60 s sustained loopback with SIGUSR2 counter dumps.
+
+### Per-session data-stream chain introspection
+
+- `_MOQTSessionMixin._dump_data_streams(file=stderr)` walks `_data_streams` and reports per-stream `StreamChain` capacity + parse progress (`bytes_total`, `group_id`, `object_id`, parser type). Returns the dict for programmatic use.
+- `aiomoqt.utils.taskdump`'s SIGUSR2 handler extended to walk live `MOQTSession` instances and emit the chain dump after the aiopquic counter dump. Tells you in one signal whether bytes are pinned at the chain layer (parser hot path) or downstream (was the diagnostic that localized the bloat above).
+
 ### WT-server d16 draft pin
 
 `MOQTSessionWTServer.__init__` now calls `set_moqt_ctx_version(session.draft_version)` symmetrically with the raw-QUIC ALPN handler and the WT-client init path. Without it, the global `moqt_version` stayed at `MOQT_VERSION_DRAFT14` on the server, so `ClientSetup.deserialize` expected the d14 wire format (version list first) while a d16 client sent the d16 format (no version list) — observable as `BufferReadError` on the first incoming `ClientSetup`. Unblocks 2-proc WT d16; validated at 2.2-2.3 Gbps p99 75ms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.9.5 (unreleased)
+
+Pairs with [aiopquic 0.3.3](https://pypi.org/project/aiopquic/0.3.3/);
+dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.3`.
+
+### Publisher `r=0` yield heuristic — pressure-based
+
+`PublishedTrack._generate_subgroup` previously yielded with
+`asyncio.sleep(0)` every 64 objects on the unbounded-rate (`-r 0`)
+path. On fast Python publish loops the count-based yield can starve
+the picoquic worker thread between yields, capping single-stream
+throughput well below the transport ceiling.
+
+Switch to `session._quic.tx_pressure(stream_id) > 0.5` as the yield
+trigger. The publisher releases the GIL whenever aiopquic reports
+its TX-ring is filling, regardless of how many objects have been
+sent. Bounded-rate (`-r N>0`) callers are unchanged — they pace via
+`asyncio.sleep(1/rate)` as before.
+
 ## v0.9.4 (2026-05-16)
 
 Pairs with [aiopquic 0.3.2](https://pypi.org/project/aiopquic/0.3.2/);

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN pip install --no-cache-dir .
 # relay (selected via MOQT_ROLE=relay). The relay binds UDP/4443 by
 # default and loads /certs/cert.pem + /certs/priv.key per the runner's
 # certs convention.
+#
+# WARNING: MOQT_ROLE=relay starts an EXPERIMENTAL control-plane-only
+# interop relay. It does not forward data, has no authentication, and
+# is not intended for any workload outside the interop conformance
+# tests. Use moxygen / moq-rs for production traffic.
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,12 @@ COPY . .
 
 RUN pip install --no-cache-dir .
 
-ENTRYPOINT ["python", "-m", "aiomoqt.examples.moq_interop_client"]
+# Role switch for the moq-interop-runner. The runner expects two
+# container shapes from a single image: a client (default) and a
+# relay (selected via MOQT_ROLE=relay). The relay binds UDP/4443 by
+# default and loads /certs/cert.pem + /certs/priv.key per the runner's
+# certs convention.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ uv pip install aiomoqt    # or: pip install aiomoqt
 
 A `./bootstrap_python.sh` script is provided for a uv-managed `.venv` if you want a clean dev environment.
 
+### Reporting issues
+
+Include the full version report in any issue. It captures aiomoqt, aiopquic, and the picoquic + picotls submodule SHAs aiopquic was built from — useful for diagnosing version-pair mismatches across the stack:
+
+```bash
+python -m aiomoqt.versions   # or the console script: aiomoqt-versions
+```
+
+Sample output:
+
+```
+aiomoqt  0.9.5.dev7+g69f55724e.d20260520
+         /path/to/aiomoqt
+aiopquic 0.3.5.dev4+g2ffe8947d.d20260522
+         /path/to/aiopquic
+picoquic 2b1e14d5a46532eadf691edef5bd747da6de6557
+picotls  f350eab60742138ac62b42ee444adf04c7898b0d
+```
+
 ## Quick Start
 
 ### Subscriber

--- a/aiomoqt/client.py
+++ b/aiomoqt/client.py
@@ -89,6 +89,8 @@ class MOQTClient(MOQTPeer):
                     max_datagram_frame_size=64 * 1024,
                     server_name=self.host,
                     secrets_log_file=self.keylog_filename,
+                    # See server.py note: BBR over NewReno.
+                    congestion_control_algorithm="bbr",
                 )
             protocol = lambda *a, **kw: MOQTSessionQuic(*a, **kw, session=self)
             # quic_debug_log not wired on raw-QUIC path yet: aiopquic

--- a/aiomoqt/client.py
+++ b/aiomoqt/client.py
@@ -28,6 +28,7 @@ class MOQTClient(MOQTPeer):
         quic_debug_log: Optional[str] = None,
         draft_version: Optional[int] = None,
         libquicr_compat: Optional[bool] = False,
+        congestion_control_algorithm: Optional[str] = "bbr",
     ):
         super().__init__(allow_optional_dgram=allow_optional_dgram,
                          libquicr_compat=libquicr_compat)
@@ -57,6 +58,7 @@ class MOQTClient(MOQTPeer):
         self.draft_version = draft_version
         self.keylog_filename = keylog_filename
         self.configuration = configuration
+        self.congestion_control_algorithm = congestion_control_algorithm
 
         if draft_version is not None:
             set_moqt_ctx_version(draft_version)
@@ -89,8 +91,10 @@ class MOQTClient(MOQTPeer):
                     max_datagram_frame_size=64 * 1024,
                     server_name=self.host,
                     secrets_log_file=self.keylog_filename,
-                    # See server.py note: BBR over NewReno.
-                    congestion_control_algorithm="bbr",
+                    # Default "bbr"; operator-overridable via MOQTClient
+                    # constructor. See server.py for rationale.
+                    congestion_control_algorithm=(
+                        self.congestion_control_algorithm),
                 )
             protocol = lambda *a, **kw: MOQTSessionQuic(*a, **kw, session=self)
             # quic_debug_log not wired on raw-QUIC path yet: aiopquic

--- a/aiomoqt/examples/adaptive_bench.py
+++ b/aiomoqt/examples/adaptive_bench.py
@@ -1112,6 +1112,7 @@ async def run_loopback_server(args, state: BenchState):
         host="localhost", port=args.port,
         certificate=args.cert, private_key=args.key,
         path="",
+        congestion_control_algorithm=args.cc_algo,
     )
     server.register_handler(
         MOQTMessageType.SUBSCRIBE, partial(_on_subscribe))
@@ -1133,6 +1134,7 @@ async def run_subscriber_client(host: str, port: int, path: str,
         use_quic=use_quic,
         verify_tls=verify_tls,
         draft_version=args.draft,
+        congestion_control_algorithm=args.cc_algo,
     )
     try:
         async with client.connect() as session:
@@ -1185,6 +1187,7 @@ async def run_publisher_client(host: str, port: int, path: str,
         use_quic=use_quic,
         verify_tls=verify_tls,
         draft_version=args.draft,
+        congestion_control_algorithm=args.cc_algo,
     )
     try:
         async with client.connect() as session:
@@ -1356,6 +1359,10 @@ def parse_args():
                         "uvloop is on by default when available — "
                         "typically 2-4× faster on selector-heavy "
                         "workloads.")
+    p.add_argument("--cc-algo", type=str, default="bbr",
+                   help="Congestion control algorithm "
+                        "(bbr | bbr1 | newreno | cubic | dcubic | "
+                        "prague | fast). Default: bbr")
     args = p.parse_args()
     args.sub_filter = filter_choices[args.sub_filter]
     if args.sub_filter in (FilterType.ABSOLUTE_START,

--- a/aiomoqt/examples/join_example.py
+++ b/aiomoqt/examples/join_example.py
@@ -20,11 +20,15 @@ def parse_args():
     parser.add_argument('--use-quic', action='store_true', help='Enable QUIC transport')
     parser.add_argument('--debug', action='store_true', help='Enable debug output')
     parser.add_argument('--keylogfile', type=str, default=None, help='TLS secrets file')
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
     return parser.parse_args()
 
 
 async def main(host: str, port: int, path: str, namespace: str, track_name: str,
-               use_quic: bool, debug: bool):
+               use_quic: bool, debug: bool, cc_algo: str = 'bbr'):
     log_level = logging.DEBUG if debug else logging.INFO
     set_log_level(log_level)
     logger = get_logger(__name__)
@@ -35,7 +39,8 @@ async def main(host: str, port: int, path: str, namespace: str, track_name: str,
         path=path,
         use_quic=use_quic,
         keylog_filename=args.keylogfile,
-        debug=debug
+        debug=debug,
+        congestion_control_algorithm=cc_algo,
     )
     logger.info(f"MOQT app: join session connecting: {client}")
     try:
@@ -92,7 +97,8 @@ if __name__ == "__main__":
             namespace=args.namespace,
             track_name=args.trackname,
             use_quic=args.use_quic,
-            debug=args.debug
+            debug=args.debug,
+            cc_algo=args.cc_algo,
         ), debug=args.debug)
 
     except KeyboardInterrupt:

--- a/aiomoqt/examples/loopback_bench.py
+++ b/aiomoqt/examples/loopback_bench.py
@@ -69,6 +69,14 @@ def parse_args():
         '--key', type=str, default=KEY)
     parser.add_argument(
         '-d', '--debug', action='store_true')
+    parser.add_argument(
+        '--quic', action='store_true',
+        help='Use raw QUIC instead of WebTransport (default: WT)')
+    parser.add_argument(
+        '--cc-algo', type=str, default='bbr',
+        help='Congestion control algorithm '
+             '(bbr | bbr1 | newreno | cubic | dcubic | prague | fast). '
+             'Default: bbr')
     return parser.parse_args()
 
 
@@ -120,6 +128,8 @@ async def run_server(args):
         host="localhost", port=args.port,
         certificate=args.cert, private_key=args.key,
         path="/",
+        use_quic=args.quic,
+        congestion_control_algorithm=args.cc_algo,
     )
     server.register_handler(
         MOQTMessageType.SUBSCRIBE,
@@ -132,8 +142,10 @@ async def run_subscriber(args, stats):
     client = MOQTClient(
         "localhost", args.port,
         path="/",
+        use_quic=args.quic,
         verify_tls=False,
         debug=args.debug,
+        congestion_control_algorithm=args.cc_algo,
     )
 
     try:
@@ -161,6 +173,11 @@ async def main():
     args = parse_args()
     log_level = logging.DEBUG if args.debug else logging.WARNING
     set_log_level(log_level)
+
+    # AIOMOQT_TASK_DUMP=1 installs SIGUSR1 (task stacks) + SIGUSR2
+    # (aiopquic counters) handlers. No-op when env not set.
+    from aiomoqt.utils.taskdump import install as _install_task_dump
+    _install_task_dump()
 
     stats = BenchStats(report_interval=args.interval)
     print_banner(args)

--- a/aiomoqt/examples/loopback_bench.py
+++ b/aiomoqt/examples/loopback_bench.py
@@ -86,9 +86,11 @@ def print_banner(args):
         rate_s = f"{args.rate}/s per stream"
     else:
         rate_s = "max"
+    transport_label = "QUIC" if args.quic else "H3/WebTransport"
     print("─" * 56)
     print("  aiomoqt-bench loopback (no relay)")
     print("─" * 56)
+    print(f"  transport:   {transport_label}")
     print(f"  mode:        {mode}")
     print(f"  object size: {args.object_size} B")
     print(f"  group size:  {args.group_size} objects")

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -70,7 +70,8 @@ SUBSCRIBE_BENIGN_ERROR_CODES = frozenset({
 # reader can see that strict spec was not met. Real failures (connection
 # refused, decode error, transport reset) are never compat-passed.
 KNOWN_COMPAT_IMPLS = frozenset({
-    "moq-dev",            # cdn.moq.dev /anon — endpoint quirks
+    "moq-dev",            # cdn.moq.dev /anon — returns 404 for not-found
+    "moq-rs",             # cloudflare moq-rs d14 — returns code=0 for not-found
     "moq-rs-d16",         # itzmanish/moq-rs draft-16 fork (CF endpoint)
     "lenient-extensions",  # tolerate truncated trailing extensions block
     "all",                # enable every known compat tolerance
@@ -359,12 +360,14 @@ async def test_subscribe_error(host, port, path, use_quic,
                                timeout=2.0) -> TestResult:
     """Test 4: SUBSCRIBE to non-existent track, expect SUBSCRIBE_ERROR.
 
-    Compat (`moq-dev`): the relay returns its own non-spec "not found"
-    code (e.g. 404). We accept *any* structured error as a valid
-    "track not found" signal with annotation. A timeout or transport
-    error still fails.
+    Compat (`moq-dev` / `moq-rs`): the relay returns its own non-spec
+    "not found" code (404 for moq-dev, 0 for moq-rs d14). We accept
+    *any* structured error as a valid "track not found" signal with
+    annotation. A timeout or transport error still fails.
     """
     moq_dev_compat = _compat_active(compat, "moq-dev")
+    moq_rs_compat = _compat_active(compat, "moq-rs")
+    accept_any_error = moq_dev_compat or moq_rs_compat
     t0 = time.monotonic()
     cid = "unknown"
     client = _make_client(host, port, path, use_quic, tls_disable_verify, debug, draft_version=draft_version)
@@ -401,7 +404,8 @@ async def test_subscribe_error(host, port, path, use_quic,
                             message=f"Error received (expected): code={e.error_code}",
                             expected="SUBSCRIBE_ERROR code=TRACK_DOES_NOT_EXIST",
                         )
-                    if moq_dev_compat:
+                    if accept_any_error:
+                        impl = "moq-rs" if moq_rs_compat else "moq-dev"
                         return TestResult(
                             name="subscribe-error", passed=True,
                             duration_ms=(time.monotonic() - t0) * 1000,
@@ -414,8 +418,9 @@ async def test_subscribe_error(host, port, path, use_quic,
                             received=f"SUBSCRIBE_ERROR code={e.error_code}",
                             compat=True,
                             compat_note=(
-                                f"moq-dev returns non-spec error code {e.error_code} "
-                                f"for not-found; spec expects 0x04 (d14) or 0x10 (d16)"
+                                f"{impl} returns non-spec error code "
+                                f"{e.error_code} for not-found; spec expects "
+                                f"0x04 (d14) or 0x10 (d16)"
                             ),
                         )
                     return TestResult(
@@ -511,6 +516,8 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
                                          timeout=3.5) -> TestResult:
     """Test 6: Subscriber connects first, publisher 500ms later. Both outcomes valid."""
     moq_dev_compat = _compat_active(compat, "moq-dev")
+    moq_rs_compat = _compat_active(compat, "moq-rs")
+    accept_any_error = moq_dev_compat or moq_rs_compat
     t0 = time.monotonic()
     pub_cid = "unknown"
     sub_cid = "unknown"
@@ -578,7 +585,8 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
             if spec_ok:
                 msg = f"Error received (valid: relay didn't buffer): code={sub_response.error_code}"
                 passed = True
-            elif moq_dev_compat:
+            elif accept_any_error:
+                impl = "moq-rs" if moq_rs_compat else "moq-dev"
                 msg = (
                     f"Non-spec error code={sub_response.error_code} accepted "
                     f"as benign 'did not buffer'"
@@ -586,7 +594,7 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
                 passed = True
                 compat_used = True
                 compat_reason = (
-                    f"moq-dev returns non-spec error code "
+                    f"{impl} returns non-spec error code "
                     f"{sub_response.error_code} for not-found; spec "
                     f"expects a benign code"
                 )

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -73,6 +73,7 @@ KNOWN_COMPAT_IMPLS = frozenset({
     "moq-dev",            # cdn.moq.dev /anon — returns 404 for not-found
     "moq-rs",             # cloudflare moq-rs d14 — returns code=0 for not-found
     "moq-rs-d16",         # itzmanish/moq-rs draft-16 fork (CF endpoint)
+    "libquicr",           # Cisco libquicr — accepts SUBSCRIBE to unknown tracks
     "lenient-extensions",  # tolerate truncated trailing extensions block
     "all",                # enable every known compat tolerance
 })
@@ -367,6 +368,7 @@ async def test_subscribe_error(host, port, path, use_quic,
     """
     moq_dev_compat = _compat_active(compat, "moq-dev")
     moq_rs_compat = _compat_active(compat, "moq-rs")
+    libquicr_compat = _compat_active(compat, "libquicr")
     accept_any_error = moq_dev_compat or moq_rs_compat
     t0 = time.monotonic()
     cid = "unknown"
@@ -382,8 +384,26 @@ async def test_subscribe_error(host, port, path, use_quic,
                         track_name="test-track",
                         wait_response=True,
                     )
-                    # If we get here, no error — unexpected
+                    # If we get here, no error.
                     session.close()
+                    if libquicr_compat:
+                        return TestResult(
+                            name="subscribe-error", passed=True,
+                            duration_ms=(time.monotonic() - t0) * 1000,
+                            connection_id=cid,
+                            message=(
+                                "SUBSCRIBE_OK for non-existent track accepted "
+                                "(libquicr deferred-delivery policy)"
+                            ),
+                            expected="error response",
+                            received="SUBSCRIBE_OK",
+                            compat=True,
+                            compat_note=(
+                                "libquicr accepts SUBSCRIBE to any track "
+                                "(deferred-delivery policy); does not "
+                                "verify track existence at subscribe time"
+                            ),
+                        )
                     return TestResult(
                         name="subscribe-error", passed=False,
                         duration_ms=(time.monotonic() - t0) * 1000,

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -510,6 +510,7 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
                                          compat=frozenset(),
                                          timeout=3.5) -> TestResult:
     """Test 6: Subscriber connects first, publisher 500ms later. Both outcomes valid."""
+    moq_dev_compat = _compat_active(compat, "moq-dev")
     t0 = time.monotonic()
     pub_cid = "unknown"
     sub_cid = "unknown"
@@ -566,6 +567,8 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
         # TRACK_DOES_NOT_EXIST or UNINTERESTED). INTERNAL_ERROR (0x0)
         # is rejected: it signals a server-side failure, not a policy
         # choice, and should not pass a conformance test.
+        compat_used = False
+        compat_reason = ""
         if sub_response is None:
             msg = "Timeout waiting for subscriber response"
             passed = False
@@ -575,6 +578,18 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
             if spec_ok:
                 msg = f"Error received (valid: relay didn't buffer): code={sub_response.error_code}"
                 passed = True
+            elif moq_dev_compat:
+                msg = (
+                    f"Non-spec error code={sub_response.error_code} accepted "
+                    f"as benign 'did not buffer'"
+                )
+                passed = True
+                compat_used = True
+                compat_reason = (
+                    f"moq-dev returns non-spec error code "
+                    f"{sub_response.error_code} for not-found; spec "
+                    f"expects a benign code"
+                )
             else:
                 msg = (
                     f"Non-conformant error: expected a benign code "
@@ -593,6 +608,8 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
             publisher_connection_id=pub_cid,
             subscriber_connection_id=sub_cid,
             message=msg,
+            compat=compat_used,
+            compat_note=compat_reason,
         )
     except Exception as e:
         return TestResult(
@@ -808,6 +825,13 @@ async def run_tests(tests: list[str], host: str, port: int, path: str,
                     reporter: TAPReporter = None) -> TAPReporter:
     if reporter is None:
         reporter = TAPReporter(compat=compat)
+    # Per-test namespace slot. Stricter relays (e.g. itzmanish/moq-rs)
+    # cache PUBLISH_NAMESPACE_DONE state, so a later test that
+    # reannounces the same namespace gets `code=0 reason=done` back.
+    # Append the test name as a final segment so each test owns its
+    # own announce slot.
+    global INTEROP_NAMESPACE
+    base_namespace = INTEROP_NAMESPACE
     for test_name in tests:
         fn = TEST_FUNCTIONS.get(test_name)
         if fn is None:
@@ -816,6 +840,7 @@ async def run_tests(tests: list[str], host: str, port: int, path: str,
                 skip_reason="Unknown test case",
             ))
             continue
+        INTEROP_NAMESPACE = f"{base_namespace}/{test_name}"
         nc_before = MOQTMessage._trailing_extensions_truncation_count
         result = await fn(host, port, path, use_quic, tls_disable_verify,
                           debug, draft_version=draft_version, compat=compat)

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -3,23 +3,37 @@
 MoQ Interop Test Client — implements the 6 standard test cases from
 https://github.com/englishm/moq-interop-runner
 
-Output: TAP version 14 with YAML diagnostics.
-CLI interface matches TEST-CLIENT-INTERFACE.md spec.
+Output: TAP version 14 with YAML diagnostics, with an ISO-8601 `# date:`
+header so published log files self-identify when they ran.
+
+CLI interface matches TEST-CLIENT-INTERFACE.md spec, plus a `--compat`
+flag for known-non-standard endpoints. Compat-tolerated outcomes are
+annotated in TAP output (`# COMPAT` directive + `compat: true` YAML
+field) so they remain visible — they are explicit acceptances of
+intentional deviations, not silent passes.
 """
 
 import argparse
 import asyncio
+import datetime
 import logging
 import os
 import sys
 import time
 from dataclasses import dataclass
-from urllib.parse import urlparse
 
+from aiomoqt.client import MOQTClient
+from aiomoqt.messages.base import MOQTMessage
 from aiomoqt.types import (
     ParamType, FetchType, MOQTRequestError,
     SubscribeErrorCode, RequestErrorCode,
 )
+from aiomoqt.utils.logger import set_log_level
+
+try:
+    from aiomoqt import __version__ as AIOMOQT_VERSION
+except Exception:
+    AIOMOQT_VERSION = "unknown"
 
 # Spec-compliant "track not found" codes across drafts:
 # d14 SubscribeErrorCode.TRACK_DOES_NOT_EXIST = 0x04
@@ -46,16 +60,66 @@ SUBSCRIBE_BENIGN_ERROR_CODES = frozenset({
     int(RequestErrorCode.NOT_SUPPORTED),
     int(RequestErrorCode.TIMEOUT),
 })
-from aiomoqt.client import MOQTClient
-from aiomoqt.utils.logger import set_log_level
+
+
+# ---------------------------------------------------------------------------
+# Compatibility flags
+# ---------------------------------------------------------------------------
+# Compat tolerates *intentional* protocol differences at specific endpoints,
+# not real errors. Each tolerance is annotated in the TAP output so a
+# reader can see that strict spec was not met. Real failures (connection
+# refused, decode error, transport reset) are never compat-passed.
+KNOWN_COMPAT_IMPLS = frozenset({
+    "moq-dev",            # cdn.moq.dev /anon — endpoint quirks
+    "moq-rs-d16",         # itzmanish/moq-rs draft-16 fork (CF endpoint)
+    "lenient-extensions",  # tolerate truncated trailing extensions block
+    "all",                # enable every known compat tolerance
+})
+
+
+def _compat_active(compat: frozenset, key: str) -> bool:
+    return "all" in compat or key in compat
+
+
+def _format_exc(e: BaseException) -> str:
+    """Informative exception text — preserves the class name when str(e) is empty.
+
+    asyncio.TimeoutError, ConnectionResetError, and several aiopquic
+    exceptions stringify to '', which produced empty `Failed: ` lines
+    in earlier interop reports. This ensures the cause is always
+    visible in the log.
+    """
+    if e is None:
+        return "<no exception>"
+    cls = type(e).__name__
+    msg = str(e)
+    if not msg:
+        return cls
+    return f"{cls}: {msg}" if cls not in msg else msg
+
+
+def _utc_now_iso() -> str:
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
 
 
 def _unique_suffix():
     """Short hex timestamp for unique namespace/track per run."""
     return hex(int(time.time()) & 0xFFFF)[2:]
 
+
 INTEROP_NAMESPACE = f"moq-test/{_unique_suffix()}/interop"
 INTEROP_TRACK = f"track-{_unique_suffix()}"
+
+# PUBLISH_NAMESPACE parameters used by the standard tests.
+# Default empty: anonymous tests should look anonymous. AUTH_TOKEN is
+# added only when --auth-token / $AUTH_TOKEN is set explicitly. Some
+# relays (notably cdn.moq.dev /anon) reject PUBLISH_NAMESPACE with
+# any AUTH_TOKEN param on their anonymous scope.
+_PUB_NS_PARAMS: dict = {}
 
 STANDARD_TESTS = [
     "setup-only",
@@ -80,24 +144,48 @@ class TestResult:
     received: str = ""
     skipped: bool = False
     skip_reason: str = ""
+    compat: bool = False        # True when result accepted under a --compat tolerance
+    compat_note: str = ""       # Human-readable reason the deviation was tolerated
+    wire_noncompliance_count: int = 0   # Spec-violating peer wire events tolerated during this test
 
 
 class TAPReporter:
-    """Emit TAP version 14 output."""
+    """Emit TAP version 14 output with run-identifying headers."""
 
-    def __init__(self):
+    def __init__(self, *, target_url: str = "",
+                 aiomoqt_version: str = "",
+                 compat: frozenset = frozenset()):
         self.results: list[TestResult] = []
+        self.target_url = target_url
+        self.aiomoqt_version = aiomoqt_version
+        self.compat = compat
+        self.started_at = _utc_now_iso()
+        self.ended_at = ""
 
     def add(self, result: TestResult):
         self.results.append(result)
 
+    def finalize(self):
+        if not self.ended_at:
+            self.ended_at = _utc_now_iso()
+
     def report(self) -> str:
-        lines = ["TAP version 14", f"1..{len(self.results)}"]
+        self.finalize()
+        lines = ["TAP version 14"]
+        lines.append(f"# date: {self.started_at}")
+        lines.append(f"# ended: {self.ended_at}")
+        if self.target_url:
+            lines.append(f"# target: {self.target_url}")
+        if self.aiomoqt_version:
+            lines.append(f"# version: aiomoqt/{self.aiomoqt_version}")
+        if self.compat:
+            lines.append(f"# compat: {','.join(sorted(self.compat))}")
+        lines.append(f"1..{len(self.results)}")
         for i, r in enumerate(self.results, 1):
             status = "ok" if r.passed else "not ok"
             skip = f" # SKIP {r.skip_reason}" if r.skipped else ""
-            lines.append(f"{status} {i} - {r.name}{skip}")
-            # YAML diagnostic block
+            tag = " # COMPAT" if r.compat and not r.skipped else ""
+            lines.append(f"{status} {i} - {r.name}{skip}{tag}")
             lines.append("  ---")
             lines.append(f"  duration_ms: {r.duration_ms:.1f}")
             if r.connection_id:
@@ -112,7 +200,23 @@ class TAPReporter:
                 lines.append(f"  expected: {r.expected}")
             if r.received:
                 lines.append(f"  received: {r.received}")
+            if r.compat:
+                lines.append("  compat: true")
+                if r.compat_note:
+                    lines.append(f"  compat_note: {r.compat_note}")
+            if r.wire_noncompliance_count:
+                lines.append(
+                    f"  wire_noncompliance: {r.wire_noncompliance_count}"
+                )
             lines.append("  ...")
+        total_noncompliance = sum(
+            r.wire_noncompliance_count for r in self.results
+        )
+        if total_noncompliance:
+            lines.append(
+                f"# wire_noncompliance_total: trailing_extensions="
+                f"{total_noncompliance}"
+            )
         return "\n".join(lines)
 
 
@@ -145,7 +249,8 @@ def _make_client(host: str, port: int, path: str, use_quic: bool,
 # ---------------------------------------------------------------------------
 
 async def test_setup_only(host, port, path, use_quic, tls_disable_verify,
-                          debug, draft_version=None, timeout=2.0) -> TestResult:
+                          debug, draft_version=None, compat=frozenset(),
+                          timeout=2.0) -> TestResult:
     """Test 1: Connect, exchange SETUP, graceful close."""
     t0 = time.monotonic()
     client = _make_client(host, port, path, use_quic, tls_disable_verify, debug, draft_version=draft_version)
@@ -165,14 +270,15 @@ async def test_setup_only(host, port, path, use_quic, tls_disable_verify,
         return TestResult(
             name="setup-only", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="SERVER_SETUP received",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
 async def test_announce_only(host, port, path, use_quic, tls_disable_verify,
-                             debug, draft_version=None, timeout=2.0) -> TestResult:
+                             debug, draft_version=None, compat=frozenset(),
+                             timeout=2.0) -> TestResult:
     """Test 2: SETUP + PUBLISH_NAMESPACE + receive OK."""
     t0 = time.monotonic()
     client = _make_client(host, port, path, use_quic, tls_disable_verify, debug, draft_version=draft_version)
@@ -184,7 +290,7 @@ async def test_announce_only(host, port, path, use_quic, tls_disable_verify,
 
                 await session.publish_namespace(
                     namespace=INTEROP_NAMESPACE,
-                    parameters={ParamType.AUTH_TOKEN: b"interop-test"},
+                    parameters=_PUB_NS_PARAMS,
                     wait_response=True,
                 )
                 session.close()
@@ -198,15 +304,17 @@ async def test_announce_only(host, port, path, use_quic, tls_disable_verify,
         return TestResult(
             name="announce-only", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="PUBLISH_NAMESPACE_OK",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
 async def test_publish_namespace_done(host, port, path, use_quic,
                                       tls_disable_verify, debug,
-                                      draft_version=None, timeout=2.0) -> TestResult:
+                                      draft_version=None,
+                                      compat=frozenset(),
+                                      timeout=2.0) -> TestResult:
     """Test 3: SETUP + PUBLISH_NAMESPACE + OK + PUBLISH_NAMESPACE_DONE + close."""
     t0 = time.monotonic()
     client = _make_client(host, port, path, use_quic, tls_disable_verify, debug, draft_version=draft_version)
@@ -218,16 +326,14 @@ async def test_publish_namespace_done(host, port, path, use_quic,
 
                 response = await session.publish_namespace(
                     namespace=INTEROP_NAMESPACE,
-                    parameters={ParamType.AUTH_TOKEN: b"interop-test"},
+                    parameters=_PUB_NS_PARAMS,
                     wait_response=True,
                 )
-                # Now send PUBLISH_NAMESPACE_DONE
                 ns_tuple = session._make_namespace_tuple(INTEROP_NAMESPACE)
                 session.publish_namespace_done(
                     namespace=ns_tuple,
                     request_id=response.request_id,
                 )
-                # Brief pause to let the message flush
                 await asyncio.sleep(0.1)
                 session.close()
 
@@ -241,16 +347,24 @@ async def test_publish_namespace_done(host, port, path, use_quic,
         return TestResult(
             name="publish-namespace-done", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="PUBLISH_NAMESPACE_OK + PUBLISH_NAMESPACE_DONE",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
 async def test_subscribe_error(host, port, path, use_quic,
                                tls_disable_verify, debug,
-                               draft_version=None, timeout=2.0) -> TestResult:
-    """Test 4: SUBSCRIBE to non-existent track, expect SUBSCRIBE_ERROR."""
+                               draft_version=None, compat=frozenset(),
+                               timeout=2.0) -> TestResult:
+    """Test 4: SUBSCRIBE to non-existent track, expect SUBSCRIBE_ERROR.
+
+    Compat (`moq-dev`): the relay returns its own non-spec "not found"
+    code (e.g. 404). We accept *any* structured error as a valid
+    "track not found" signal with annotation. A timeout or transport
+    error still fails.
+    """
+    moq_dev_compat = _compat_active(compat, "moq-dev")
     t0 = time.monotonic()
     cid = "unknown"
     client = _make_client(host, port, path, use_quic, tls_disable_verify, debug, draft_version=draft_version)
@@ -277,38 +391,58 @@ async def test_subscribe_error(host, port, path, use_quic,
                     )
                 except MOQTRequestError as e:
                     session.close()
-                    spec_ok = int(e.error_code) in TRACK_NOT_FOUND_CODES
+                    code = int(e.error_code)
+                    spec_ok = code in TRACK_NOT_FOUND_CODES
+                    if spec_ok:
+                        return TestResult(
+                            name="subscribe-error", passed=True,
+                            duration_ms=(time.monotonic() - t0) * 1000,
+                            connection_id=cid,
+                            message=f"Error received (expected): code={e.error_code}",
+                            expected="SUBSCRIBE_ERROR code=TRACK_DOES_NOT_EXIST",
+                        )
+                    if moq_dev_compat:
+                        return TestResult(
+                            name="subscribe-error", passed=True,
+                            duration_ms=(time.monotonic() - t0) * 1000,
+                            connection_id=cid,
+                            message=(
+                                f"Non-spec error code={e.error_code} accepted "
+                                f"as 'track not found'"
+                            ),
+                            expected="SUBSCRIBE_ERROR code=TRACK_DOES_NOT_EXIST (0x04/0x10)",
+                            received=f"SUBSCRIBE_ERROR code={e.error_code}",
+                            compat=True,
+                            compat_note=(
+                                f"moq-dev returns non-spec error code {e.error_code} "
+                                f"for not-found; spec expects 0x04 (d14) or 0x10 (d16)"
+                            ),
+                        )
                     return TestResult(
-                        name="subscribe-error",
-                        passed=spec_ok,
+                        name="subscribe-error", passed=False,
                         duration_ms=(time.monotonic() - t0) * 1000,
                         connection_id=cid,
                         message=(
-                            f"Error received (expected): "
-                            f"code={e.error_code}"
-                            if spec_ok else
                             f"Non-conformant: expected TRACK_DOES_NOT_EXIST "
                             f"(d14=0x04 / d16=0x10), got code={e.error_code}"
                         ),
                         expected="SUBSCRIBE_ERROR code=TRACK_DOES_NOT_EXIST",
-                        received=(
-                            "" if spec_ok
-                            else f"SUBSCRIBE_ERROR code={e.error_code}"
-                        ),
+                        received=f"SUBSCRIBE_ERROR code={e.error_code}",
                     )
     except Exception as e:
         return TestResult(
             name="subscribe-error", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="error response",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
 async def test_announce_subscribe(host, port, path, use_quic,
                                   tls_disable_verify, debug,
-                                  draft_version=None, timeout=3.0) -> TestResult:
+                                  draft_version=None, compat=frozenset(),
+                                  timeout=3.0) -> TestResult:
     """Test 5: Two connections — publisher announces, subscriber subscribes."""
     t0 = time.monotonic()
     pub_cid = "unknown"
@@ -326,10 +460,9 @@ async def test_announce_subscribe(host, port, path, use_quic,
                 await pub_session.client_session_init()
                 pub_cid = _get_connection_id(pub_session)
 
-                # Publisher announces namespace
                 await pub_session.publish_namespace(
                     namespace=INTEROP_NAMESPACE,
-                    parameters={ParamType.AUTH_TOKEN: b"interop-test"},
+                    parameters=_PUB_NS_PARAMS,
                     wait_response=True,
                 )
 
@@ -366,13 +499,16 @@ async def test_announce_subscribe(host, port, path, use_quic,
             duration_ms=(time.monotonic() - t0) * 1000,
             publisher_connection_id=pub_cid,
             subscriber_connection_id=sub_cid,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
+            received=_format_exc(e),
         )
 
 
 async def test_subscribe_before_announce(host, port, path, use_quic,
                                          tls_disable_verify, debug,
-                                         draft_version=None, timeout=3.5) -> TestResult:
+                                         draft_version=None,
+                                         compat=frozenset(),
+                                         timeout=3.5) -> TestResult:
     """Test 6: Subscriber connects first, publisher 500ms later. Both outcomes valid."""
     t0 = time.monotonic()
     pub_cid = "unknown"
@@ -408,7 +544,7 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
 
                     await pub_session.publish_namespace(
                         namespace=INTEROP_NAMESPACE,
-                        parameters={ParamType.AUTH_TOKEN: b"interop-test"},
+                        parameters=_PUB_NS_PARAMS,
                         wait_response=True,
                     )
 
@@ -434,16 +570,18 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
             msg = "Timeout waiting for subscriber response"
             passed = False
         elif isinstance(sub_response, MOQTRequestError):
-            spec_ok = int(sub_response.error_code) in SUBSCRIBE_BENIGN_ERROR_CODES
-            passed = spec_ok
-            msg = (
-                f"Error received (valid: relay didn't buffer): "
-                f"code={sub_response.error_code}"
-                if spec_ok else
-                f"Non-conformant error: expected a benign code "
-                f"(TRACK_DOES_NOT_EXIST / UNAUTHORIZED / TIMEOUT / "
-                f"NOT_SUPPORTED), got code={sub_response.error_code}"
-            )
+            code = int(sub_response.error_code)
+            spec_ok = code in SUBSCRIBE_BENIGN_ERROR_CODES
+            if spec_ok:
+                msg = f"Error received (valid: relay didn't buffer): code={sub_response.error_code}"
+                passed = True
+            else:
+                msg = (
+                    f"Non-conformant error: expected a benign code "
+                    f"(TRACK_DOES_NOT_EXIST / UNAUTHORIZED / TIMEOUT / "
+                    f"NOT_SUPPORTED), got code={sub_response.error_code}"
+                )
+                passed = False
         else:
             msg = ("SUBSCRIBE_OK received after delayed announce "
                    "(relay buffered)")
@@ -462,12 +600,14 @@ async def test_subscribe_before_announce(host, port, path, use_quic,
             duration_ms=(time.monotonic() - t0) * 1000,
             publisher_connection_id=pub_cid,
             subscriber_connection_id=sub_cid,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
+            received=_format_exc(e),
         )
 
 
 async def test_fetch(host, port, path, use_quic, tls_disable_verify,
-                     debug, draft_version=None, timeout=3.0) -> TestResult:
+                     debug, draft_version=None, compat=frozenset(),
+                     timeout=3.0) -> TestResult:
     """FETCH probe: send a standalone FETCH; relay handles if it responds
     with FETCH_OK or structured FETCH_ERROR. Timeout/close = fail."""
     t0 = time.monotonic()
@@ -507,14 +647,15 @@ async def test_fetch(host, port, path, use_quic, tls_disable_verify,
         return TestResult(
             name="fetch", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="FETCH_OK or FETCH_ERROR",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
 async def test_join(host, port, path, use_quic, tls_disable_verify,
-                    debug, draft_version=None, timeout=3.0) -> TestResult:
+                    debug, draft_version=None, compat=frozenset(),
+                    timeout=3.0) -> TestResult:
     """JOIN probe: send SUBSCRIBE + JOINING_FETCH(RELATIVE, start=0).
     Relay handles if it responds (OK or structured error). Timeout = fail."""
     t0 = time.monotonic()
@@ -553,9 +694,9 @@ async def test_join(host, port, path, use_quic, tls_disable_verify,
         return TestResult(
             name="join", passed=False,
             duration_ms=(time.monotonic() - t0) * 1000,
-            message=f"Failed: {e}",
+            message=f"Failed: {_format_exc(e)}",
             expected="SUBSCRIBE_OK + FETCH_OK or structured error",
-            received=str(e),
+            received=_format_exc(e),
         )
 
 
@@ -584,11 +725,31 @@ def parse_relay_url(url: str):
     return r.host, r.port, r.path or "", r.use_quic
 
 
+def parse_compat(raw: str) -> frozenset:
+    """Parse comma-separated --compat / $COMPAT value into a normalized set."""
+    if not raw:
+        return frozenset()
+    parts = {p.strip().lower() for p in raw.split(",") if p.strip()}
+    unknown = parts - KNOWN_COMPAT_IMPLS
+    if unknown:
+        print(
+            f"# warning: unknown --compat values ignored: "
+            f"{','.join(sorted(unknown))} "
+            f"(known: {','.join(sorted(KNOWN_COMPAT_IMPLS))})",
+            file=sys.stderr,
+        )
+    return frozenset(parts & KNOWN_COMPAT_IMPLS)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="MoQ Interop Test Client (aiomoqt)",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="Environment variables: RELAY_URL, TESTCASE, TLS_DISABLE_VERIFY, VERBOSE",
+        epilog=(
+            "Environment variables: RELAY_URL, TESTCASE, "
+            "TLS_DISABLE_VERIFY, VERBOSE, COMPAT, "
+            "NAMESPACE_PREFIX, AUTH_TOKEN"
+        ),
     )
     parser.add_argument("-r", "--relay", type=str,
                         default=os.environ.get("RELAY_URL", "https://localhost"),
@@ -608,13 +769,45 @@ def parse_args():
                         help="Enable debug logging to stderr")
     parser.add_argument("--draft", type=int, default=None,
                         help="MoQT draft version (14 or 16, default: auto/14)")
+    parser.add_argument(
+        "--compat", type=str, default=os.environ.get("COMPAT", ""),
+        help=(
+            "Comma-separated list of compatibility tolerances for known "
+            "non-standard endpoints. Known: "
+            + ",".join(sorted(KNOWN_COMPAT_IMPLS))
+            + ". Tolerated outcomes are annotated with '# COMPAT' in TAP "
+              "output and 'compat: true' in the YAML block."
+        ),
+    )
+    parser.add_argument(
+        "--namespace-prefix", type=str,
+        default=os.environ.get("NAMESPACE_PREFIX", ""),
+        help=(
+            "Prefix segment(s) prepended to the test namespace. "
+            "Required for relays that scope publish/subscribe "
+            "permission by namespace prefix (e.g. cdn.moq.dev /anon "
+            "permits only 'anon/*'). Default empty."
+        ),
+    )
+    parser.add_argument(
+        "--auth-token", type=str,
+        default=os.environ.get("AUTH_TOKEN", ""),
+        help=(
+            "Send the given token as the AUTH_TOKEN parameter on "
+            "PUBLISH_NAMESPACE messages. Default empty (no AUTH_TOKEN "
+            "sent); some anonymous-scope relays reject any AUTH_TOKEN."
+        ),
+    )
     return parser.parse_args()
 
 
 async def run_tests(tests: list[str], host: str, port: int, path: str,
                     use_quic: bool, tls_disable_verify: bool,
-                    debug: bool, draft_version: int = None) -> TAPReporter:
-    reporter = TAPReporter()
+                    debug: bool, draft_version: int = None,
+                    compat: frozenset = frozenset(),
+                    reporter: TAPReporter = None) -> TAPReporter:
+    if reporter is None:
+        reporter = TAPReporter(compat=compat)
     for test_name in tests:
         fn = TEST_FUNCTIONS.get(test_name)
         if fn is None:
@@ -623,12 +816,33 @@ async def run_tests(tests: list[str], host: str, port: int, path: str,
                 skip_reason="Unknown test case",
             ))
             continue
+        nc_before = MOQTMessage._trailing_extensions_truncation_count
         result = await fn(host, port, path, use_quic, tls_disable_verify,
-                          debug, draft_version=draft_version)
+                          debug, draft_version=draft_version, compat=compat)
+        nc_delta = (
+            MOQTMessage._trailing_extensions_truncation_count - nc_before
+        )
+        result.wire_noncompliance_count = nc_delta
+        # If the test owed its pass to wire tolerance (and wasn't
+        # already annotated by a per-test compat policy), surface the
+        # acceptance the same way moq-dev tolerances are surfaced.
+        if (
+            nc_delta > 0
+            and result.passed
+            and not result.compat
+            and MOQTMessage._tolerate_trailing_extensions
+        ):
+            result.compat = True
+            result.compat_note = (
+                f"peer sent {nc_delta} non-compliant trailing "
+                f"extensions block(s); tolerated via "
+                f"--compat lenient-extensions"
+            )
         reporter.add(result)
         # Print progress to stderr if verbose
         status = "PASS" if result.passed else "FAIL"
-        print(f"  [{status}] {result.name}: {result.message}", file=sys.stderr)
+        tag = " (COMPAT)" if result.compat else ""
+        print(f"  [{status}{tag}] {result.name}: {result.message}", file=sys.stderr)
     return reporter
 
 
@@ -647,6 +861,26 @@ def main():
                         format="%(levelname)s %(name)s: %(message)s")
 
     host, port, path, use_quic = parse_relay_url(args.relay)
+    compat = parse_compat(args.compat)
+
+    # Plumb the wire-tolerance flag into the deserializer module
+    # before any session is created. Without this the parser stays
+    # strict and a malformed extensions block raises through the
+    # control-message dispatcher (default policy).
+    if _compat_active(compat, "lenient-extensions"):
+        MOQTMessage._tolerate_trailing_extensions = True
+
+    # Apply namespace prefix and auth-token, if set, before the
+    # tests capture INTEROP_NAMESPACE / _PUB_NS_PARAMS from module
+    # scope. Both flags default off so anonymous tests look anonymous.
+    global INTEROP_NAMESPACE, _PUB_NS_PARAMS
+    prefix = args.namespace_prefix.strip("/")
+    if prefix:
+        INTEROP_NAMESPACE = f"{prefix}/{INTEROP_NAMESPACE}"
+    if args.auth_token:
+        _PUB_NS_PARAMS = {
+            ParamType.AUTH_TOKEN: args.auth_token.encode(),
+        }
 
     # Public API takes the draft NUMBER (14, 16, ...). MOQTClient
     # normalizes to the wire form internally; pass args.draft through.
@@ -657,22 +891,34 @@ def main():
         draft_str = f" draft-{args.draft}" if args.draft else ""
         print(f"# Relay: {args.relay} ({host}:{port}/{path} via {transport}{draft_str})",
               file=sys.stderr)
+        print(f"# Namespace: {INTEROP_NAMESPACE}", file=sys.stderr)
+        if args.auth_token:
+            print("# Auth: AUTH_TOKEN set", file=sys.stderr)
+        if compat:
+            print(f"# Compat: {','.join(sorted(compat))}", file=sys.stderr)
+
+    reporter = TAPReporter(
+        target_url=args.relay,
+        aiomoqt_version=AIOMOQT_VERSION,
+        compat=compat,
+    )
 
     # Select tests
     if args.test:
         if args.test not in TEST_FUNCTIONS:
-            print("TAP version 14")
-            print("1..1")
+            print(reporter.report())  # emits headers + 1..0
             print(f"not ok 1 - {args.test} # SKIP unsupported test case")
             sys.exit(127)
         tests = [args.test]
     else:
         tests = STANDARD_TESTS
 
-    reporter = asyncio.run(
+    asyncio.run(
         run_tests(tests, host, port, path, use_quic,
                   args.tls_disable_verify, args.debug,
-                  draft_version=draft_version)
+                  draft_version=draft_version,
+                  compat=compat,
+                  reporter=reporter)
     )
 
     # TAP output to stdout

--- a/aiomoqt/examples/moq_interop_relay.py
+++ b/aiomoqt/examples/moq_interop_relay.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Minimal MoQT relay for the interop runner.
+
+Implements just enough control-plane to satisfy the 6 standard interop
+test cases at https://github.com/englishm/moq-interop-runner. There is
+no actual data forwarding: the suite tests SETUP / PUBLISH_NAMESPACE /
+SUBSCRIBE / PUBLISH_NAMESPACE_DONE flow and never sends objects.
+
+Routing model (cross-session, single relay instance):
+  - PUBLISH_NAMESPACE: record the namespace tuple in `_announced`,
+    respond with the protocol's default RequestOk (d16+) /
+    PublishNamespaceOk (d14).
+  - SUBSCRIBE: if the requested (namespace, track_name) namespace is in
+    `_announced`, respond with SUBSCRIBE_OK. Otherwise send
+    SUBSCRIBE_ERROR with TRACK_DOES_NOT_EXIST (d14 code 0x04,
+    d16 code 0x10) so the conformance suite's subscribe-error test sees
+    a spec-correct rejection.
+  - PUBLISH_NAMESPACE_DONE: remove the namespace from `_announced`.
+
+Run on UDP/4443 with the runner's /certs convention:
+
+  python -m aiomoqt.examples.moq_interop_relay \\
+      --bind 0.0.0.0 --port 4443 \\
+      --cert /certs/cert.pem --key /certs/priv.key
+
+Accepts both raw QUIC and WebTransport on the same port via two
+parallel listeners (different UDP-port binds with separate ALPNs would
+require a second port; for the runner we serve WT only by default and
+add `--quic` to swap to raw QUIC).
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from functools import partial
+
+from aiomoqt.server import MOQTServer
+from aiomoqt.types import (
+    MOQTMessageType, RequestErrorCode, SubscribeErrorCode,
+)
+from aiomoqt.messages.request import RequestError
+from aiomoqt.context import is_draft16_or_later
+from aiomoqt.utils.logger import set_log_level, get_logger
+
+logger = get_logger(__name__)
+
+
+# Global cross-session announcement table. Maps namespace tuple (as a
+# tuple of bytes) to a count of active publishers. Sub-tests within the
+# same suite can re-announce / un-announce; the count lets that work.
+_announced: dict[tuple, int] = {}
+
+
+def _ns_tuple(namespace):
+    """Normalize a namespace value (str / list / tuple of bytes-or-str)
+    into a tuple of bytes for use as a dict key."""
+    if isinstance(namespace, str):
+        return tuple(s.encode() for s in namespace.split("/") if s)
+    if isinstance(namespace, (list, tuple)):
+        return tuple(
+            s.encode() if isinstance(s, str) else bytes(s)
+            for s in namespace
+        )
+    return tuple()
+
+
+async def _on_publish_namespace(session, msg):
+    """Record the namespace, ack with default OK path."""
+    ns = _ns_tuple(msg.namespace)
+    _announced[ns] = _announced.get(ns, 0) + 1
+    logger.info(f"relay: announce ns={ns} -> count={_announced[ns]}")
+    # Reuse the protocol's built-in OK helper. It emits RequestOk on
+    # d16+ and PublishNamespaceOk on d14, matching peer expectation.
+    session.publish_namepace_ok(msg)
+
+
+async def _on_publish_namespace_done(session, msg):
+    """Drop one publisher's hold on the namespace."""
+    ns = _ns_tuple(msg.namespace) if msg.namespace else None
+    if ns is None or ns not in _announced:
+        logger.info(f"relay: publish_namespace_done for unknown ns={ns}")
+        return
+    _announced[ns] -= 1
+    if _announced[ns] <= 0:
+        del _announced[ns]
+    logger.info(f"relay: namespace_done ns={ns} -> "
+                f"{_announced.get(ns, 0)} remaining")
+
+
+async def _on_subscribe(session, msg):
+    """Accept SUBSCRIBE for announced namespaces, error otherwise."""
+    ns = _ns_tuple(msg.track_namespace)
+    if ns in _announced:
+        logger.info(f"relay: subscribe ns={ns} track={msg.track_name} "
+                    f"-> SUBSCRIBE_OK")
+        session.subscribe_ok(request_msg=msg)
+        return
+    logger.info(f"relay: subscribe ns={ns} track={msg.track_name} "
+                f"-> ERROR (not announced)")
+    # On d16+ the universal REQUEST_ERROR (0x05) carries the not-found
+    # code (0x10). On d14 the legacy SUBSCRIBE_ERROR (0x05) carries
+    # TRACK_DOES_NOT_EXIST (0x04). Send the right shape per version.
+    if is_draft16_or_later():
+        err = RequestError(
+            request_id=msg.request_id,
+            error_code=int(RequestErrorCode.DOES_NOT_EXIST),
+            retry_interval=0,
+            reason="track does not exist",
+        )
+        logger.info(f"MOQT send: {err}")
+        session.send_control_message(err.serialize())
+    else:
+        session.subscribe_error(
+            request_id=msg.request_id,
+            error_code=int(SubscribeErrorCode.TRACK_DOES_NOT_EXIST),
+            reason="track does not exist",
+        )
+
+
+def _find_default_cert():
+    candidates = [
+        '/certs/cert.pem',
+        os.path.join(os.path.dirname(__file__),
+                     '..', '..', 'certs', 'cert.pem'),
+        os.path.expanduser('~/.local/share/moqt/cert.pem'),
+    ]
+    for c in candidates:
+        if os.path.exists(c):
+            return os.path.realpath(c)
+    return None
+
+
+def _find_default_key(cert_path):
+    if not cert_path:
+        return None
+    for name in ('priv.key', 'key.pem'):
+        candidate = os.path.join(os.path.dirname(cert_path), name)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="MoQT interop-runner relay (control-plane only)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--bind", type=str, default="0.0.0.0",
+                        help="Bind address (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=4443,
+                        help="UDP listen port (default: 4443)")
+    parser.add_argument("--cert", type=str, default=None,
+                        help="TLS cert PEM "
+                             "(default: /certs/cert.pem)")
+    parser.add_argument("--key", type=str, default=None,
+                        help="TLS key PEM "
+                             "(default: /certs/priv.key)")
+    parser.add_argument("--quic", action="store_true",
+                        help="Serve raw QUIC instead of WebTransport")
+    parser.add_argument("--draft", type=int, default=16,
+                        help="MoQT draft version (default: 16)")
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable debug logging")
+    return parser.parse_args()
+
+
+async def main():
+    args = parse_args()
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    set_log_level(log_level)
+    logging.basicConfig(
+        level=log_level, stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    cert = args.cert or _find_default_cert()
+    key = args.key or _find_default_key(cert)
+    if not cert or not key:
+        print("Error: TLS cert/key required. Use --cert/--key or place "
+              "cert.pem+priv.key at /certs/", file=sys.stderr)
+        sys.exit(2)
+
+    server = MOQTServer(
+        host=args.bind, port=args.port,
+        certificate=cert, private_key=key,
+        path="/",
+        use_quic=args.quic,
+        draft_version=args.draft,
+    )
+    server.register_handler(
+        MOQTMessageType.PUBLISH_NAMESPACE, _on_publish_namespace)
+    server.register_handler(
+        MOQTMessageType.PUBLISH_NAMESPACE_DONE, _on_publish_namespace_done)
+    server.register_handler(
+        MOQTMessageType.SUBSCRIBE, _on_subscribe)
+
+    quic_server = await server.serve()
+
+    transport = "raw QUIC" if args.quic else "H3/WebTransport"
+    print(f"MoQT interop relay listening on {args.bind}:{args.port} "
+          f"({transport}, draft-{args.draft})", file=sys.stderr)
+
+    try:
+        await asyncio.Event().wait()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        quic_server.close()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/aiomoqt/examples/moq_interop_relay.py
+++ b/aiomoqt/examples/moq_interop_relay.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
-"""Minimal MoQT relay for the interop runner.
+"""EXPERIMENTAL — minimal MoQT interop relay (not a production relay).
 
-Implements just enough control-plane to satisfy the 6 standard interop
-test cases at https://github.com/englishm/moq-interop-runner. There is
-no actual data forwarding: the suite tests SETUP / PUBLISH_NAMESPACE /
-SUBSCRIBE / PUBLISH_NAMESPACE_DONE flow and never sends objects.
+This is a CONTROL-PLANE-ONLY skeleton intended solely for exercising
+the 6 standard interop test cases at
+https://github.com/englishm/moq-interop-runner. It has:
+
+  * NO data forwarding (objects are never relayed)
+  * NO multi-subscriber fan-out
+  * NO authentication, authorization, or rate limiting
+  * NO load handling, backpressure, or production hardening
+  * An in-memory namespace table that is global to the process
+
+Use moxygen, moq-rs, or another real relay for any actual workload.
+This relay exists so aiomoqt's server-side primitives (MOQTServer,
+the announce / subscribe handlers) have a working demonstrator and
+so we can run the interop conformance suite against ourselves.
 
 Routing model (cross-session, single relay instance):
   - PUBLISH_NAMESPACE: record the namespace tuple in `_announced`,
@@ -34,7 +44,6 @@ import asyncio
 import logging
 import os
 import sys
-from functools import partial
 
 from aiomoqt.server import MOQTServer
 from aiomoqt.types import (
@@ -200,7 +209,15 @@ async def main():
     quic_server = await server.serve()
 
     transport = "raw QUIC" if args.quic else "H3/WebTransport"
-    print(f"MoQT interop relay listening on {args.bind}:{args.port} "
+    print(
+        "=" * 64
+        + "\n EXPERIMENTAL aiomoqt interop relay — control-plane only.\n"
+        " NOT a production relay: no data forwarding, no auth,\n"
+        " no scale handling. Use moxygen / moq-rs for real workloads.\n"
+        + "=" * 64,
+        file=sys.stderr,
+    )
+    print(f"Listening on {args.bind}:{args.port} "
           f"({transport}, draft-{args.draft})", file=sys.stderr)
 
     try:

--- a/aiomoqt/examples/multi_sub_bench.py
+++ b/aiomoqt/examples/multi_sub_bench.py
@@ -92,6 +92,10 @@ def parse_args():
                         help='Seconds to wait for publisher before spawning subs (default: 5)')
     parser.add_argument('--logdir', type=str, default=None,
                         help='Directory for per-process debug logs (pub.log, sub-N.log)')
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
     return parser.parse_args()
 
 
@@ -121,6 +125,7 @@ def run_publisher(relay_url, namespace, trackname, args):
             use_quic=relay.use_quic,
             verify_tls=not args.insecure,
             draft_version=args.draft,
+            congestion_control_algorithm=args.cc_algo,
         )
         async with client.connect() as session:
             await session.client_session_init()
@@ -192,6 +197,7 @@ def run_subscriber(sub_id, relay_url, namespace, trackname, args,
             use_quic=relay.use_quic,
             verify_tls=not args.insecure,
             draft_version=args.draft,
+            congestion_control_algorithm=args.cc_algo,
         )
         start = time.monotonic()
         try:

--- a/aiomoqt/examples/pub_bench.py
+++ b/aiomoqt/examples/pub_bench.py
@@ -130,6 +130,12 @@ async def run(args):
     log_level = logging.DEBUG if args.debug else logging.WARNING
     set_log_level(log_level)
 
+    # AIOMOQT_TASK_DUMP=1 installs a SIGUSR1 handler that dumps every
+    # asyncio task's stack to stderr. Useful for diagnosing hangs:
+    # `kill -USR1 <pid>` while the bench is stuck. No-op when unset.
+    from aiomoqt.utils.taskdump import install as _install_task_dump
+    _install_task_dump()
+
     relay = parse_relay_url(args.relay, force_quic=args.force_quic)
     print_banner(relay, args)
 

--- a/aiomoqt/examples/pub_bench.py
+++ b/aiomoqt/examples/pub_bench.py
@@ -88,6 +88,10 @@ examples:
                         help='Skip TLS certificate verification')
     parser.add_argument('--draft', type=int, default=None,
                         help='MoQT draft version (e.g. 14, 16)')
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
     args = parser.parse_args()
     if args.trackname is None:
         import uuid
@@ -147,6 +151,7 @@ async def run(args):
         draft_version=args.draft,
         debug=args.debug,
         keylog_filename=args.keylogfile,
+        congestion_control_algorithm=args.cc_algo,
     )
 
     print(f"  Connecting...")

--- a/aiomoqt/examples/pub_example.py
+++ b/aiomoqt/examples/pub_example.py
@@ -253,6 +253,10 @@ def parse_args():
     parser.add_argument('--gop-pattern', type=str, default='ibp',
                         choices=['ibp', 'ip', 'ionly'],
                         help='GOP pattern (default: ibp)')
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
 
     return parser.parse_args()
 
@@ -261,7 +265,8 @@ async def main(host: str, port: int, path: str, namespace: str, trackname: str,
                debug: bool, datagram: bool, use_quic: bool, quic_debug: bool,
                insecure: bool = False, auth_token: str = None, draft: int = None,
                streams: int = 1, object_size: int = 1024, rate: float = 30,
-               duration: int = 120, video: str = None, gop_pattern: str = 'ibp'):
+               duration: int = 120, video: str = None, gop_pattern: str = 'ibp',
+               cc_algo: str = 'bbr'):
     log_level = logging.DEBUG if debug else logging.INFO
     set_log_level(log_level)
     logger = get_logger(__name__)
@@ -275,6 +280,7 @@ async def main(host: str, port: int, path: str, namespace: str, trackname: str,
         draft_version=draft,
         debug=debug,
         keylog_filename=args.keylogfile,
+        congestion_control_algorithm=cc_algo,
     )
 
     auth = auth_token.encode() if auth_token else b""
@@ -340,6 +346,7 @@ if __name__ == "__main__":
             duration=args.duration,
             video=args.video,
             gop_pattern=args.gop_pattern,
+            cc_algo=args.cc_algo,
         ))
 
     except KeyboardInterrupt:

--- a/aiomoqt/examples/pub_server.py
+++ b/aiomoqt/examples/pub_server.py
@@ -93,6 +93,11 @@ def parse_args():
     parser.add_argument(
         '-d', '--debug', action='store_true',
         help='Enable debug output')
+    parser.add_argument(
+        '--cc-algo', type=str, default='bbr',
+        help='Congestion control algorithm '
+             '(bbr | bbr1 | newreno | cubic | dcubic | prague | fast). '
+             'Default: bbr')
     return parser.parse_args()
 
 
@@ -153,6 +158,7 @@ async def main():
         use_quic=args.quic,
         tx_max_inflight_bytes=args.max_inflight_bytes,
         draft_version=args.draft,
+        congestion_control_algorithm=args.cc_algo,
     )
     server.register_handler(
         MOQTMessageType.SUBSCRIBE,

--- a/aiomoqt/examples/pub_server.py
+++ b/aiomoqt/examples/pub_server.py
@@ -112,7 +112,15 @@ async def _on_subscribe(session, msg, args):
     track._generating = True
     logger.info(f"Subscriber connected, generating data "
                 f"({args.object_size}B x {args.streams} streams)")
-    await track.generate(session, ok.track_alias)
+    try:
+        await track.generate(session, ok.track_alias)
+    except BaseException as e:
+        import sys, traceback
+        print(f"\n=== _on_subscribe: track.generate raised {type(e).__name__}: {e} ===",
+              file=sys.stderr, flush=True)
+        traceback.print_exc(file=sys.stderr)
+        print("=== end ===\n", file=sys.stderr, flush=True)
+        raise
 
 
 async def main():
@@ -121,6 +129,12 @@ async def main():
     args = parse_args()
     log_level = logging.DEBUG if args.debug else logging.WARNING
     set_log_level(log_level)
+
+    # AIOMOQT_TASK_DUMP=1 installs a SIGUSR1 handler that dumps every
+    # asyncio task's stack to stderr. Useful for diagnosing hangs:
+    # `kill -USR1 <pid>` while the server is stuck. No-op when unset.
+    from aiomoqt.utils.taskdump import install as _install_task_dump
+    _install_task_dump()
 
     if not args.cert or not args.key:
         print("Error: TLS certificate required. "
@@ -158,8 +172,9 @@ async def main():
         print(f"  python -m aiomoqt.examples.sub_bench "
               f"moqt://{args.host}:{args.port} -t 30 -i 5 --draft {args.draft} -k")
     else:
+        # WT path matches MOQTServer(path="/") above; no /moq suffix.
         print(f"  python -m aiomoqt.examples.sub_bench "
-              f"https://{args.host}:{args.port}/moq -t 30 -i 5 -k")
+              f"https://{args.host}:{args.port}/ -t 30 -i 5 --draft {args.draft} -k")
 
     try:
         await asyncio.Event().wait()

--- a/aiomoqt/examples/pub_server.py
+++ b/aiomoqt/examples/pub_server.py
@@ -67,6 +67,12 @@ def parse_args():
         '-r', '--rate', type=float, default=0,
         help='Objects/sec per stream (0=max, default: max)')
     parser.add_argument(
+        '--max-inflight-bytes', type=int, default=None,
+        help='Producer backpressure: pause once aiopquic reports this '
+             'many bytes pending in the TX ring (default: unbounded). '
+             'Bounds queue depth and tail latency. e.g. 2_000_000 ~10ms '
+             '@ 1.6 Gbps.')
+    parser.add_argument(
         '-Q', '--quic', action='store_true',
         help='Serve raw QUIC (aiopquic) instead of H3/WebTransport')
     parser.add_argument(
@@ -131,6 +137,7 @@ async def main():
         certificate=args.cert, private_key=args.key,
         path="/",
         use_quic=args.quic,
+        tx_max_inflight_bytes=args.max_inflight_bytes,
         draft_version=args.draft,
     )
     server.register_handler(

--- a/aiomoqt/examples/relay_bench.py
+++ b/aiomoqt/examples/relay_bench.py
@@ -72,6 +72,11 @@ examples:
     parser.add_argument(
         '-k', '--insecure', action='store_true',
         help='Skip TLS certificate verification')
+    parser.add_argument(
+        '--cc-algo', type=str, default='bbr',
+        help='Congestion control algorithm '
+             '(bbr | bbr1 | newreno | cubic | dcubic | prague | fast). '
+             'Default: bbr')
     return parser.parse_args()
 
 
@@ -93,6 +98,7 @@ async def main():
         debug=args.debug,
         keylogfile=args.keylogfile,
         insecure=args.insecure,
+        cc_algo=args.cc_algo,
     )
 
     sub_args = argparse.Namespace(
@@ -105,6 +111,7 @@ async def main():
         debug=args.debug,
         keylogfile=args.keylogfile,
         insecure=args.insecure,
+        cc_algo=args.cc_algo,
     )
 
     # Import run functions

--- a/aiomoqt/examples/server_example.py
+++ b/aiomoqt/examples/server_example.py
@@ -18,7 +18,11 @@ def parse_args():
     parser.add_argument('--debug', action='store_true', help='Enable debug output')
     parser.add_argument('--quic-debug', action='store_true',  help='Enable quic debug output')
     parser.add_argument('--keylogfile', type=str, default=None, help='TLS secrets file')
-    
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
+
     return parser.parse_args()
 
 async def main(args):
@@ -32,7 +36,8 @@ async def main(args):
         certificate=args.certificate,
         private_key=args.private_key,
         path=args.path,
-        debug=args.debug
+        debug=args.debug,
+        congestion_control_algorithm=args.cc_algo,
     )
 
     logger.info(f"MOQT server: starting session: {server}")

--- a/aiomoqt/examples/sub_bench.py
+++ b/aiomoqt/examples/sub_bench.py
@@ -315,6 +315,11 @@ examples:
     parser.add_argument(
         '--draft', type=int, default=None,
         help='MoQT draft version (e.g. 14, 16)')
+    parser.add_argument(
+        '--cc-algo', type=str, default='bbr',
+        help='Congestion control algorithm '
+             '(bbr | bbr1 | newreno | cubic | dcubic | prague | fast). '
+             'Default: bbr')
     return parser.parse_args()
 
 
@@ -355,6 +360,7 @@ async def run(args):
         draft_version=args.draft,
         debug=args.debug,
         keylog_filename=args.keylogfile,
+        congestion_control_algorithm=args.cc_algo,
     )
 
     try:

--- a/aiomoqt/examples/sub_bench.py
+++ b/aiomoqt/examples/sub_bench.py
@@ -336,6 +336,12 @@ async def run(args):
                  else logging.WARNING)
     set_log_level(log_level)
 
+    # AIOMOQT_TASK_DUMP=1 installs a SIGUSR1 handler that dumps every
+    # asyncio task's stack to stderr. Useful for diagnosing hangs:
+    # `kill -USR1 <pid>` while the bench is stuck. No-op when unset.
+    from aiomoqt.utils.taskdump import install as _install_task_dump
+    _install_task_dump()
+
     relay = parse_relay_url(
         args.relay, force_quic=args.force_quic)
     stats = BenchStats(report_interval=args.interval)

--- a/aiomoqt/examples/sub_bench.py
+++ b/aiomoqt/examples/sub_bench.py
@@ -15,7 +15,14 @@ import argparse
 import asyncio
 import logging
 import math
+import os
 import time
+import tracemalloc
+
+# Opt-in memory profiling: AIOMOQT_TRACEMALLOC=1 enables tracemalloc and
+# dumps top allocators at exit. Default off — zero perf impact when unset.
+if os.environ.get("AIOMOQT_TRACEMALLOC") == "1":
+    tracemalloc.start(25)  # 25-frame stack capture per allocation
 
 from aiomoqt.types import (
     ParamType, MOQTException, MOQTRequestError,
@@ -396,6 +403,14 @@ async def run(args):
         print(f"  Connection failed: {e}")
 
     stats.print_summary()
+
+    if tracemalloc.is_tracing():
+        snap = tracemalloc.take_snapshot()
+        top = snap.statistics("filename")
+        print("\n=== tracemalloc top 25 by filename ===")
+        for stat in top[:25]:
+            print(f"  {stat.size / (1024 * 1024):8.1f} MB  "
+                  f"{stat.count:>8d} blocks  {stat.traceback}")
 
 
 if __name__ == "__main__":

--- a/aiomoqt/examples/sub_example.py
+++ b/aiomoqt/examples/sub_example.py
@@ -30,6 +30,10 @@ def parse_args():
     parser.add_argument('-t', '--duration', type=int, default=120, help='Duration in seconds (default: 120)')
     parser.add_argument('--subscribe-options', type=int, default=None,
                         help='d16 subscribe_namespace options: 0=PUBLISH, 1=NAMESPACE, 2=both')
+    parser.add_argument('--cc-algo', type=str, default='bbr',
+                        help='Congestion control algorithm '
+                             '(bbr | bbr1 | newreno | cubic | dcubic | '
+                             'prague | fast). Default: bbr')
 
     return parser.parse_args()
 
@@ -138,7 +142,8 @@ async def main(host: str, port: int, path: str, namespace: str, track_name: str,
                use_quic: bool, debug: bool, quic_debug: bool, insecure: bool = False,
                auth_token: str = None, draft: int = None, libquicr_compat: bool = False,
                duration: int = 120,
-               subscribe_options: int = None):
+               subscribe_options: int = None,
+               cc_algo: str = 'bbr'):
     log_level = logging.DEBUG if debug else logging.INFO
     set_log_level(log_level)
     logger = get_logger(__name__)
@@ -154,6 +159,7 @@ async def main(host: str, port: int, path: str, namespace: str, track_name: str,
         libquicr_compat=libquicr_compat,
         debug=debug,
         keylog_filename=args.keylogfile,
+        congestion_control_algorithm=cc_algo,
     )
     logger.info(f"MOQT app: subscribe session connecting: {client}")
     try:
@@ -207,6 +213,7 @@ if __name__ == "__main__":
             libquicr_compat=args.libquicr_compat,
             duration=args.duration,
             subscribe_options=args.subscribe_options,
+            cc_algo=args.cc_algo,
         ), debug=args.debug)
 
     except KeyboardInterrupt:

--- a/aiomoqt/messages/base.py
+++ b/aiomoqt/messages/base.py
@@ -91,6 +91,16 @@ class MOQTMessage:
     exts_err_count = 0
     EXTENSIONS_LEN_LIMIT = 1024 * 16
 
+    # Wire-noncompliance tolerance. Strict by default: a truncated
+    # trailing extensions block (peer's wire-level msg_len declares
+    # more bytes than form a valid KVP) is a spec violation and is
+    # raised through the normal control-message error path. Interop
+    # clients can opt-in to tolerance by setting this flag; truncation
+    # then becomes a counted, ERROR-logged event and the partially
+    # parsed dict is returned so the rest of the message dispatches.
+    _tolerate_trailing_extensions = False
+    _trailing_extensions_truncation_count = 0
+
     @staticmethod
     def _extensions_decode(buf: Buffer, with_length: bool = True,
                            buf_end: Optional[int] = None) -> Optional[Dict[int, Union[int, bytes]]]:
@@ -153,17 +163,51 @@ class MOQTMessage:
         while buf.tell() < exts_end:
             kvp_start = buf.tell()
             # BufferReadError (aliased as MOQTUnderflow) means the
-            # underlying buffer ran out mid-pull — the caller's
-            # re-buffering path uses this to wait for more data, so
-            # let it propagate without wrapping.
-            ext_id = buf.pull_uint_var()
-            if ext_id % 2 == 0:
-                # even type → varint value (self-bounded by varint prefix)
-                ext_value = buf.pull_uint_var()
-            else:
-                # odd type → length-prefixed bytes value
-                value_len = buf.pull_uint_var()
-                ext_value = buf.pull_bytes(value_len)
+            # underlying buffer ran out mid-pull. For data streams
+            # (with_length=True) the caller's re-buffering path uses
+            # this to wait for more data, so let it propagate.
+            # For control messages (with_length=False) the buffer is
+            # single-shot: a truncation here means the peer sent a
+            # message whose wire-level length declares more extension
+            # bytes than were actually transmitted (we have seen this
+            # from relays during teardown). Returning the partial dict
+            # lets the dispatcher process the message body (which we
+            # already finished parsing) without a noisy traceback.
+            try:
+                ext_id = buf.pull_uint_var()
+                if ext_id % 2 == 0:
+                    # even type → varint value (self-bounded by varint prefix)
+                    ext_value = buf.pull_uint_var()
+                else:
+                    # odd type → length-prefixed bytes value
+                    value_len = buf.pull_uint_var()
+                    ext_value = buf.pull_bytes(value_len)
+            except BufferReadError:
+                if with_length:
+                    raise
+                # Trailing extensions block on a control message is
+                # truncated: the peer's wire-level msg_len declares
+                # more bytes than form a valid KVP. This is a spec
+                # violation (d16 §9.13). Count it regardless of
+                # policy so the event is always recorded.
+                MOQTMessage._trailing_extensions_truncation_count += 1
+                if not MOQTMessage._tolerate_trailing_extensions:
+                    raise RuntimeError(
+                        f"non-compliant peer: truncated trailing "
+                        f"extensions block (kvp_start={kvp_start} "
+                        f"tell={buf.tell()} exts_end={exts_end} "
+                        f"parsed_kvps={len(exts)})"
+                    )
+                logger.error(
+                    "MOQT wire non-compliance tolerated: truncated "
+                    "trailing extensions block "
+                    "(kvp_start=%d tell=%d exts_end=%d) — "
+                    "returned %d KVPs; enabled by "
+                    "--compat lenient-extensions",
+                    kvp_start, buf.tell(), exts_end, len(exts),
+                )
+                buf.seek(exts_end)
+                return exts if exts else None
             if buf.tell() > exts_end:
                 # KVP read succeeded against buf.capacity but crossed
                 # our logical end-of-message — malformed framing.

--- a/aiomoqt/messages/publish.py
+++ b/aiomoqt/messages/publish.py
@@ -118,9 +118,10 @@ class Publish(MOQTMessage):
                 content_exists = ContentExistsCode.NO_CONTENT
             track_extensions = MOQTMessage._extensions_decode(
                 buf, with_length=False, buf_end=buf_end)
-            go_val = track_extensions.pop(0x22, None)
-            if go_val is not None:
-                group_order = go_val
+            if track_extensions is not None:
+                go_val = track_extensions.pop(0x22, None)
+                if go_val is not None:
+                    group_order = go_val
         else:
             group_order = buf.pull_uint8()
             content_exists = buf.pull_uint8()

--- a/aiomoqt/messages/subscribe.py
+++ b/aiomoqt/messages/subscribe.py
@@ -481,9 +481,10 @@ class SubscribeOk(MOQTMessage):
                 content_exists = ContentExistsCode.NO_CONTENT
             track_extensions = MOQTMessage._extensions_decode(
                 buf, with_length=False, buf_end=buf_end)
-            group_order_val = track_extensions.pop(0x22, None)
-            if group_order_val is not None:
-                group_order = GroupOrder(group_order_val)
+            if track_extensions is not None:
+                group_order_val = track_extensions.pop(0x22, None)
+                if group_order_val is not None:
+                    group_order = GroupOrder(group_order_val)
         else:
             expires = buf.pull_uint_var()
             group_order = GroupOrder(buf.pull_uint8())

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -1252,37 +1252,62 @@ class _MOQTSessionMixin:
                     f"[DESYNC-TRACE TX] stream({stream_id}) first write "
                     f"len={len(data) if data else 0} fin={end_stream} "
                     f"head_hex={head}")
-        # WT connection objects don't yet implement get_tx_drain_event;
-        # fall back to polling sleep on that path.
+        # Per-stream sc->tx wakeup (signaled when picoquic worker drains
+        # this stream's outbound byte ring). WT connection objects may
+        # not implement get_tx_drain_event yet — fall back path below.
         get_event = getattr(self._quic, 'get_tx_drain_event', None)
-        event = get_event(stream_id) if get_event is not None else None
+        sc_event = get_event(stream_id) if get_event is not None else None
+        # Connection-global TX SPSC ring wakeup (signaled when worker
+        # drains the event ring below low-water while we've armed
+        # tx_ring_drain_pending). Use this for ring-pressure waits;
+        # the per-stream sc_event is only armed when sc->tx fills.
+        transport = getattr(self._quic, '_transport', None)
+        ring_event = (transport.tx_ring_drain_event
+                       if transport is not None else None)
+        max_bytes = self._session.tx_max_inflight_bytes
         while True:
             if not self._session_writable():
                 return
-            # Bytes-aware producer backpressure. When the caller has
-            # set MOQTPeer.tx_max_inflight_bytes and the TX-ring's
-            # pending byte total exceeds it, wait for a drain rather
-            # than queuing more. Bounds queue-time-in-flight to
-            # (max_inflight_bytes / drain_rate) regardless of object
-            # size or ring entry capacity. Independent of the ring-
-            # entry-count threshold below.
-            max_bytes = self._session.tx_max_inflight_bytes
-            if (event is not None and max_bytes is not None
+            # Bytes-aware producer backpressure. tx_pending_bytes is
+            # per-stream sc->tx->used in the pull model — so the wait
+            # MUST align with sc->tx drain (per-stream sc_event), NOT
+            # SPSC ring drain (connection-global ring_event). Wrong
+            # alignment causes a busy-loop-throttle: producer wakes on
+            # every MARK_ACTIVE pop, rechecks sc->tx, finds it still
+            # > max_bytes, waits again — throughput collapses to the
+            # rate at which the SPSC ring cycles.
+            sc_ptr = (self._quic._stream_ctxs.get(stream_id)
+                      if hasattr(self._quic, '_stream_ctxs') else None)
+            if (transport is not None and sc_event is not None
+                    and sc_ptr and max_bytes is not None
                     and self._quic.tx_pending_bytes(stream_id) > max_bytes):
-                event.clear()
-                await event.wait()
+                sc_event.clear()
+                transport.arm_stream_tx_drain_pending(sc_ptr)
+                if self._quic.tx_pending_bytes(stream_id) <= max_bytes:
+                    transport.clear_stream_tx_drain_pending(sc_ptr)
+                    continue
+                await sc_event.wait()
                 continue
-            # Above the hard event-ratio threshold, also wait for a
-            # drain — bounds ring fill independent of object size.
-            # This is the ring-saturation guard; the byte-bound check
-            # above kicks in earlier for latency-sensitive callers.
-            if (event is not None
+            # Ring-fill saturation guard (connection-global tx_pressure).
+            # Same clear-arm-recheck-wait pattern.
+            if (transport is not None and ring_event is not None
                     and self._quic.tx_pressure(stream_id) > 0.9):
-                event.clear()
-                await event.wait()
+                ring_event.clear()
+                transport.arm_tx_ring_drain_pending()
+                if self._quic.tx_pressure(stream_id) <= 0.9:
+                    transport.clear_tx_ring_drain_pending()
+                    continue
+                await ring_event.wait()
                 continue
-            if event is not None:
-                event.clear()
+            # Clear both events BEFORE the send. If the worker fires
+            # them during our send_stream_data call (race between
+            # Cython arming and us catching the exception), the set
+            # will land AFTER our clear → captured on the wait.
+            # Clearing AFTER the BufferError loses the wakeup.
+            if sc_event is not None:
+                sc_event.clear()
+            if ring_event is not None:
+                ring_event.clear()
             try:
                 self._quic.send_stream_data(
                     stream_id, data, end_stream=end_stream)
@@ -1296,8 +1321,22 @@ class _MOQTSessionMixin:
                     await asyncio.sleep(0)
                 return
             except BufferError:
-                if event is not None:
-                    await event.wait()
+                # Cython side armed the appropriate signal — sc->tx full
+                # arms per-stream event; TX-ring full arms connection-
+                # global event. Wait on whichever fires first; events
+                # were cleared BEFORE the call so no lost wakeup.
+                if sc_event is not None and ring_event is not None:
+                    sc_wait = asyncio.create_task(sc_event.wait())
+                    ring_wait = asyncio.create_task(ring_event.wait())
+                    done, pending = await asyncio.wait(
+                        [sc_wait, ring_wait],
+                        return_when=asyncio.FIRST_COMPLETED)
+                    for t in pending:
+                        t.cancel()
+                elif sc_event is not None:
+                    await sc_event.wait()
+                elif ring_event is not None:
+                    await ring_event.wait()
                 else:
                     await asyncio.sleep(0.0001)
             except (AssertionError, AttributeError) as e:
@@ -1836,7 +1875,7 @@ class _MOQTSessionMixin:
         if not wait_response:
             return message
 
-        return self._await_response(request_id)
+        return await self._await_response(request_id)
 
     def subscribe_namespace_ok(
         self,
@@ -2382,7 +2421,7 @@ class _WTSessionMixin:
         dispatch through that path. Falls back to WebTransportSession
         base handling for session-level signals (ready/closed)."""
         super()._on_event(ev_tuple)
-        evt_type, sid, data, _is_fin, error_code, _cnx, _ = ev_tuple
+        evt_type, sid, data, _is_fin, error_code, _cnx, _, _sc = ev_tuple
         from aiopquic.quic.events import (
             StreamDataReceived as _SD, StreamReset as _SR,
             StopSendingReceived as _SS, DatagramFrameReceived as _DG,

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -2468,4 +2468,8 @@ class MOQTSessionWTServer(
 
     def __init__(self, transport, state, *, session: 'MOQTPeer'):
         super().__init__(transport, state, session=session)
+        draft = getattr(session, 'draft_version', None)
+        if draft is not None:
+            set_moqt_ctx_version(draft)
+            self._moqt_version = draft
         self._moqt_wt_finalize()

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -1238,6 +1238,14 @@ class _MOQTSessionMixin:
             try:
                 self._quic.send_stream_data(
                     stream_id, data, end_stream=end_stream)
+                # Soft backpressure: release the GIL when the picoquic
+                # worker has TX entries pending. Without this, a fast
+                # publish loop can monopolize the event loop on Python
+                # paths where send_stream_data succeeds repeatedly
+                # without ever awaiting (no hard BufferError), starving
+                # the worker.
+                if self._quic.tx_pressure(stream_id) > 0.5:
+                    await asyncio.sleep(0)
                 return
             except BufferError:
                 if event is not None:

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -459,6 +459,47 @@ class _MOQTSessionMixin:
             )
             raise
 
+    def _dump_data_streams(self, file=None) -> dict:
+        """Per-stream chain-introspection. Returns and prints a dict of
+        {stream_id: (chain_chunks, chain_total_bytes, bytes_parsed,
+                     group_id, object_id, parser_type)}.
+        Used by SIGUSR2 to localize where bytes are pinned downstream
+        of aiopquic's drain. Called from aiomoqt.utils.taskdump."""
+        import sys
+        if file is None:
+            file = sys.stderr
+        out = {}
+        total_chains = 0
+        total_chunks = 0
+        total_bytes = 0
+        for sid, state in self._data_streams.items():
+            chain = state.chain
+            # _chunks is the internal deque; len() is the count.
+            try:
+                chunks_n = len(chain._chunks)
+            except Exception:
+                chunks_n = -1
+            total_chunks += max(0, chunks_n)
+            total_bytes += chain.capacity
+            total_chains += 1
+            out[sid] = (chunks_n, chain.capacity, state.bytes_total,
+                        state.group_id, state.object_id,
+                        type(state.parser).__name__ if state.parser
+                        else None)
+        print(f"=== aiomoqt chain-dump "
+              f"({total_chains} active streams, "
+              f"{total_chunks} chunks pinned, "
+              f"{total_bytes} bytes pending parse) ===",
+              file=file, flush=True)
+        for sid in sorted(out.keys()):
+            n_chunks, cap, parsed, gid, oid, pt = out[sid]
+            print(f"  sid={sid:<5} chunks={n_chunks:<6} "
+                  f"chain_bytes={cap:<10} parsed={parsed:<12} "
+                  f"group={gid} object={oid} parser={pt}",
+                  file=file, flush=True)
+        print(f"=== end chain-dump ===", file=file, flush=True)
+        return out
+
     def _cleanup_stream(self, stream_id: int,
                         error_code: int = QuicErrorCode.NO_ERROR) -> None:
         """Per-uni-stream end-of-life. Replaces the per-task done
@@ -2419,8 +2460,18 @@ class _WTSessionMixin:
         """Translate WT-specific events into the QuicEvent classes
         the mixin's quic_event_received already handles, then
         dispatch through that path. Falls back to WebTransportSession
-        base handling for session-level signals (ready/closed)."""
-        super()._on_event(ev_tuple)
+        base handling for session-level signals (ready/closed).
+
+        IMPORTANT: For event types we translate AND dispatch via
+        quic_event_received here, we MUST NOT call super()._on_event
+        — the base WebTransportSession enqueues those events into
+        per-stream inbox / session event queues that we never drain,
+        which pins the data memoryview (and the StreamChunk behind
+        it) forever. That was the WT-bloat root cause: chunks_alive
+        grew unbounded because every WT_STREAM_DATA event held a
+        memoryview ref via the never-drained _stream_inbox queue.
+        Only call super() for event types we do NOT translate here.
+        """
         evt_type, sid, data, _is_fin, error_code, _cnx, _, _sc = ev_tuple
         from aiopquic.quic.events import (
             StreamDataReceived as _SD, StreamReset as _SR,
@@ -2431,6 +2482,17 @@ class _WTSessionMixin:
             _EVT_WT_STREAM_RESET, _EVT_WT_STOP_SENDING,
             _EVT_WT_DATAGRAM,
         )
+        translated = {
+            _EVT_WT_STREAM_DATA, _EVT_WT_STREAM_FIN,
+            _EVT_WT_STREAM_RESET, _EVT_WT_STOP_SENDING,
+            _EVT_WT_DATAGRAM,
+        }
+        if evt_type not in translated:
+            # Session-level events (ready/closed/draining, new_stream,
+            # tx_drained, etc) still need base handling for queue/event
+            # signaling; they don't carry stream payload that pins
+            # chunks.
+            super()._on_event(ev_tuple)
         if evt_type == _EVT_WT_STREAM_DATA:
             self.quic_event_received(_SD(stream_id=sid, data=data,
                                           end_stream=False))

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -54,11 +54,28 @@ class MOQTStreamReject(Exception):
 # base class for client and server session objects
 class MOQTPeer:
     """MOQT client and server base-class."""
-    def __init__(self, allow_optional_dgram: bool = False, libquicr_compat: bool = False):
+    def __init__(self, allow_optional_dgram: bool = False,
+                 libquicr_compat: bool = False,
+                 tx_max_inflight_bytes: Optional[int] = 2_000_000):
         #  message handlers
         self._control_msg_handlers: Dict[int, Tuple[Type, Callable]] = {}
         self.allow_optional_dgram = allow_optional_dgram
         self.libquicr_compat = libquicr_compat
+        # Bytes-aware producer backpressure target. When set,
+        # MOQTSession.stream_write_drain awaits a TX-ring drain before
+        # pushing more bytes once aiopquic reports tx_pending_bytes()
+        # above this threshold. Independent of the SPSC ring's entry
+        # capacity (settable via QuicConfiguration.event_ring_capacity).
+        #
+        # Default 2 MB corresponds to ~10 ms of queue at 1.6 Gbps drain
+        # — a reasonable starting point across typical workloads. Pass
+        # None to opt out of the byte cap entirely (the ring's entry
+        # capacity becomes the only backpressure boundary).
+        #
+        # Sizing: target_latency_ms * target_throughput_bytes_per_sec.
+        # Future API (0.9.6+): tx_target_latency_ms with auto-tracked
+        # drain rate, so callers can express the budget directly.
+        self.tx_max_inflight_bytes = tx_max_inflight_bytes
 
     def register_handler(self, msg_type: int, handler: Callable) -> None:
         """Register a custom message handler."""
@@ -1233,6 +1250,28 @@ class _MOQTSessionMixin:
         while True:
             if not self._session_writable():
                 return
+            # Bytes-aware producer backpressure. When the caller has
+            # set MOQTPeer.tx_max_inflight_bytes and the TX-ring's
+            # pending byte total exceeds it, wait for a drain rather
+            # than queuing more. Bounds queue-time-in-flight to
+            # (max_inflight_bytes / drain_rate) regardless of object
+            # size or ring entry capacity. Independent of the ring-
+            # entry-count threshold below.
+            max_bytes = self._session.tx_max_inflight_bytes
+            if (event is not None and max_bytes is not None
+                    and self._quic.tx_pending_bytes(stream_id) > max_bytes):
+                event.clear()
+                await event.wait()
+                continue
+            # Above the hard event-ratio threshold, also wait for a
+            # drain — bounds ring fill independent of object size.
+            # This is the ring-saturation guard; the byte-bound check
+            # above kicks in earlier for latency-sensitive callers.
+            if (event is not None
+                    and self._quic.tx_pressure(stream_id) > 0.9):
+                event.clear()
+                await event.wait()
+                continue
             if event is not None:
                 event.clear()
             try:

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -36,6 +36,14 @@ USER_AGENT = f"aiomoqt/{version('aiomoqt')}"
 logger = get_logger(__name__)
 
 
+# Producer-side bytes cap on the aiopquic TX SPSC ring. Used as the
+# default for MOQTPeer.tx_max_inflight_bytes. 2 MB corresponds to ~10 ms
+# of queue at 1.6 Gbps drain — a workable starting point across typical
+# bandwidths. A future tx_target_latency_ms API will derive the byte
+# budget from a latency target + auto-tracked drain rate.
+DEFAULT_TX_MAX_INFLIGHT_BYTES = 2_000_000
+
+
 class MOQTStreamReject(Exception):
     """Raised by the data-stream parser when an incoming uni stream fails
     MoQT-level admission (unknown request_id/track_alias, budget exceeded,
@@ -56,7 +64,8 @@ class MOQTPeer:
     """MOQT client and server base-class."""
     def __init__(self, allow_optional_dgram: bool = False,
                  libquicr_compat: bool = False,
-                 tx_max_inflight_bytes: Optional[int] = 2_000_000):
+                 tx_max_inflight_bytes: Optional[int] =
+                     DEFAULT_TX_MAX_INFLIGHT_BYTES):
         #  message handlers
         self._control_msg_handlers: Dict[int, Tuple[Type, Callable]] = {}
         self.allow_optional_dgram = allow_optional_dgram

--- a/aiomoqt/server.py
+++ b/aiomoqt/server.py
@@ -59,6 +59,13 @@ class MOQTServer(MOQTPeer):
                 alpn_protocols=alpn, is_client=False,
                 max_data=2**24, max_stream_data=2**24,
                 max_datagram_frame_size=64 * 1024,
+                # BBR over picoquic's default NewReno. NewReno collapses
+                # to cwin=2*MSS on misdetected loss (e.g. GIL contention
+                # spiking loopback RTT 10000x), then can't recover and
+                # the connection enters an RTO storm until disconnect.
+                # BBR's delay-based behavior tolerates transient RTT
+                # spikes without collapsing.
+                congestion_control_algorithm="bbr",
             )
             cfg.load_cert_chain(self.certificate, self.private_key)
             protocol = lambda *a, **kw: MOQTSessionQuic(*a, **kw, session=self)

--- a/aiomoqt/server.py
+++ b/aiomoqt/server.py
@@ -25,8 +25,9 @@ class MOQTServer(MOQTPeer):
         use_quic: Optional[bool] = False,
         draft_version: Optional[int] = None,
         debug: Optional[bool] = False,
+        tx_max_inflight_bytes: Optional[int] = None,
     ):
-        super().__init__()
+        super().__init__(tx_max_inflight_bytes=tx_max_inflight_bytes)
         self.host = host
         self.port = port
         self.path = path

--- a/aiomoqt/server.py
+++ b/aiomoqt/server.py
@@ -26,6 +26,7 @@ class MOQTServer(MOQTPeer):
         draft_version: Optional[int] = None,
         debug: Optional[bool] = False,
         tx_max_inflight_bytes: Optional[int] = None,
+        congestion_control_algorithm: Optional[str] = "bbr",
     ):
         super().__init__(tx_max_inflight_bytes=tx_max_inflight_bytes)
         self.host = host
@@ -42,6 +43,7 @@ class MOQTServer(MOQTPeer):
         self.certificate = certificate
         self.private_key = private_key
         self.debug = debug
+        self.congestion_control_algorithm = congestion_control_algorithm
         self._loop = asyncio.get_running_loop()
         self._server_closed: Future[Tuple[int, str]] = self._loop.create_future()
         self._next_subscribe_id = 1
@@ -59,13 +61,12 @@ class MOQTServer(MOQTPeer):
                 alpn_protocols=alpn, is_client=False,
                 max_data=2**24, max_stream_data=2**24,
                 max_datagram_frame_size=64 * 1024,
-                # BBR over picoquic's default NewReno. NewReno collapses
-                # to cwin=2*MSS on misdetected loss (e.g. GIL contention
-                # spiking loopback RTT 10000x), then can't recover and
-                # the connection enters an RTO storm until disconnect.
-                # BBR's delay-based behavior tolerates transient RTT
-                # spikes without collapsing.
-                congestion_control_algorithm="bbr",
+                # Default "bbr" — NewReno collapses to cwin=2*MSS on
+                # misdetected loss (GIL-induced loopback RTT spikes)
+                # and can't recover. Operator-overridable via
+                # MOQTServer(congestion_control_algorithm=...).
+                congestion_control_algorithm=(
+                    self.congestion_control_algorithm),
             )
             cfg.load_cert_chain(self.certificate, self.private_key)
             protocol = lambda *a, **kw: MOQTSessionQuic(*a, **kw, session=self)

--- a/aiomoqt/track.py
+++ b/aiomoqt/track.py
@@ -431,15 +431,8 @@ class PublishedTrack(Track):
                     next_frame_time += 1.0 / current_rate
                     sleep_time = max(0, next_frame_time - time.monotonic())
                     await asyncio.sleep(sleep_time)
-                else:
-                    # Pressure-based yield: release the GIL when the
-                    # picoquic worker has pending TX entries to drain.
-                    # A pure count-based yield can starve the worker
-                    # on fast Python paths (one syscall sending many
-                    # objects per batch), so use the soft signal from
-                    # aiopquic instead.
-                    if session._quic.tx_pressure(stream_id) > 0.5:
-                        await asyncio.sleep(0)
+                # No explicit yield in the r=0 path: stream_write_drain
+                # handles pressure-based GIL release internally.
 
         except asyncio.CancelledError:
             # Sender cancelled mid-subgroup → spec wants a RESET so the
@@ -843,15 +836,8 @@ class VideoTrack(PublishedTrack):
                     sleep_time = max(0,
                         next_frame_time - time.monotonic())
                     await asyncio.sleep(sleep_time)
-                else:
-                    # Pressure-based yield: release the GIL when the
-                    # picoquic worker has pending TX entries to drain.
-                    # A pure count-based yield can starve the worker
-                    # on fast Python paths (one syscall sending many
-                    # objects per batch), so use the soft signal from
-                    # aiopquic instead.
-                    if session._quic.tx_pressure(stream_id) > 0.5:
-                        await asyncio.sleep(0)
+                # No explicit yield in the r=0 path: stream_write_drain
+                # handles pressure-based GIL release internally.
 
         except asyncio.CancelledError:
             dur = time.monotonic() - start_time

--- a/aiomoqt/track.py
+++ b/aiomoqt/track.py
@@ -432,7 +432,13 @@ class PublishedTrack(Track):
                     sleep_time = max(0, next_frame_time - time.monotonic())
                     await asyncio.sleep(sleep_time)
                 else:
-                    if local_sent % 64 == 0:
+                    # Pressure-based yield: release the GIL when the
+                    # picoquic worker has pending TX entries to drain.
+                    # A pure count-based yield can starve the worker
+                    # on fast Python paths (one syscall sending many
+                    # objects per batch), so use the soft signal from
+                    # aiopquic instead.
+                    if session._quic.tx_pressure(stream_id) > 0.5:
                         await asyncio.sleep(0)
 
         except asyncio.CancelledError:
@@ -838,7 +844,13 @@ class VideoTrack(PublishedTrack):
                         next_frame_time - time.monotonic())
                     await asyncio.sleep(sleep_time)
                 else:
-                    if local_sent % 64 == 0:
+                    # Pressure-based yield: release the GIL when the
+                    # picoquic worker has pending TX entries to drain.
+                    # A pure count-based yield can starve the worker
+                    # on fast Python paths (one syscall sending many
+                    # objects per batch), so use the soft signal from
+                    # aiopquic instead.
+                    if session._quic.tx_pressure(stream_id) > 0.5:
                         await asyncio.sleep(0)
 
         except asyncio.CancelledError:

--- a/aiomoqt/utils/taskdump.py
+++ b/aiomoqt/utils/taskdump.py
@@ -1,14 +1,21 @@
-"""SIGUSR1 asyncio task-dump diagnostic.
+"""SIGUSR1 / SIGUSR2 diagnostic signal handlers.
 
-When AIOMOQT_TASK_DUMP=1 is set, install() registers a SIGUSR1 handler
-that prints every asyncio Task's stack to stderr. Send the signal during
-a hang to see exactly what every coroutine is awaiting:
+When AIOMOQT_TASK_DUMP=1 is set, install() registers:
 
-    kill -USR1 <pid>
+  SIGUSR1: asyncio task-dump. Prints every asyncio Task's stack to
+    stderr — use for "what's every coroutine awaiting" diagnosis.
+        kill -USR1 <pid>
 
-Default-off so production runs aren't surprised by a registered signal
-handler they didn't ask for. Idempotent: calling install() twice with
-the env var set just re-registers the same handler.
+  SIGUSR2: aiopquic counter-dump. Walks the live TransportContext
+    registry and prints per-context forensic counters (tx_ring
+    pushes/pops/arms/fires, wake calls, sc->tx drain arms/fires,
+    ns-resolution timestamps). Use to localize wake-chain stalls:
+    arms-without-fires, pops-without-pushes, etc.
+        kill -USR2 <pid>
+
+Default-off so production runs aren't surprised by registered signal
+handlers they didn't ask for. Idempotent: calling install() twice
+with the env var set just re-registers the same handlers.
 """
 from __future__ import annotations
 
@@ -18,14 +25,14 @@ import sys
 
 
 def install() -> bool:
-    """Register the SIGUSR1 handler iff AIOMOQT_TASK_DUMP=1 in env.
+    """Register SIGUSR1 + SIGUSR2 handlers iff AIOMOQT_TASK_DUMP=1.
 
     Returns True if installed, False otherwise.
     """
     if not os.environ.get("AIOMOQT_TASK_DUMP"):
         return False
 
-    def _dump(signum, frame):
+    def _dump_tasks(signum, frame):
         import asyncio
         try:
             tasks = list(asyncio.all_tasks())
@@ -54,9 +61,31 @@ def install() -> bool:
         print("=== end task-dump ===\n", file=sys.stderr)
         sys.stderr.flush()
 
-    signal.signal(signal.SIGUSR1, _dump)
+    def _dump_counters(signum, frame):
+        # Lazy import — aiopquic may not be importable in every
+        # context that loads aiomoqt (tests, tooling). Failing here
+        # should not break the SIGUSR1 task-dump path.
+        try:
+            from aiopquic._binding._transport import dump_all_counters
+        except ImportError as e:
+            print(f"(SIGUSR2 counter-dump: aiopquic unavailable: {e})",
+                  file=sys.stderr, flush=True)
+            return
+        print(f"\n=== aiopquic counter-dump (SIGUSR2) ===",
+              file=sys.stderr, flush=True)
+        try:
+            dump_all_counters(file=sys.stderr)
+        except Exception as e:
+            print(f"(SIGUSR2 counter-dump failed: {e})",
+                  file=sys.stderr, flush=True)
+        print("=== end counter-dump ===\n",
+              file=sys.stderr, flush=True)
+
+    signal.signal(signal.SIGUSR1, _dump_tasks)
+    signal.signal(signal.SIGUSR2, _dump_counters)
     print(
-        "(AIOMOQT_TASK_DUMP=1: SIGUSR1 will dump asyncio task stacks)",
+        "(AIOMOQT_TASK_DUMP=1: SIGUSR1=task stacks, "
+        "SIGUSR2=aiopquic counters)",
         file=sys.stderr,
     )
     return True

--- a/aiomoqt/utils/taskdump.py
+++ b/aiomoqt/utils/taskdump.py
@@ -78,7 +78,34 @@ def install() -> bool:
         except Exception as e:
             print(f"(SIGUSR2 counter-dump failed: {e})",
                   file=sys.stderr, flush=True)
-        print("=== end counter-dump ===\n",
+        print("=== end counter-dump ===",
+              file=sys.stderr, flush=True)
+
+        # Per-session data-stream chain stats. Localizes where bytes
+        # are pinned downstream of aiopquic's drain.
+        try:
+            import gc
+            seen = 0
+            for obj in gc.get_objects():
+                try:
+                    dumper = getattr(obj, '_dump_data_streams', None)
+                    streams = getattr(obj, '_data_streams', None)
+                    if (dumper is None or not callable(dumper)
+                            or not isinstance(streams, dict)):
+                        continue
+                    print(f"\n=== aiomoqt session #{seen} ===",
+                          file=sys.stderr, flush=True)
+                    dumper(file=sys.stderr)
+                    seen += 1
+                except Exception:
+                    continue
+            if seen == 0:
+                print("(no live MOQTSession instances)",
+                      file=sys.stderr, flush=True)
+        except Exception as e:
+            print(f"(SIGUSR2 chain-dump failed: {e})",
+                  file=sys.stderr, flush=True)
+        print("=== end SIGUSR2 ===\n",
               file=sys.stderr, flush=True)
 
     signal.signal(signal.SIGUSR1, _dump_tasks)

--- a/aiomoqt/utils/taskdump.py
+++ b/aiomoqt/utils/taskdump.py
@@ -1,0 +1,62 @@
+"""SIGUSR1 asyncio task-dump diagnostic.
+
+When AIOMOQT_TASK_DUMP=1 is set, install() registers a SIGUSR1 handler
+that prints every asyncio Task's stack to stderr. Send the signal during
+a hang to see exactly what every coroutine is awaiting:
+
+    kill -USR1 <pid>
+
+Default-off so production runs aren't surprised by a registered signal
+handler they didn't ask for. Idempotent: calling install() twice with
+the env var set just re-registers the same handler.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+
+
+def install() -> bool:
+    """Register the SIGUSR1 handler iff AIOMOQT_TASK_DUMP=1 in env.
+
+    Returns True if installed, False otherwise.
+    """
+    if not os.environ.get("AIOMOQT_TASK_DUMP"):
+        return False
+
+    def _dump(signum, frame):
+        import asyncio
+        try:
+            tasks = list(asyncio.all_tasks())
+        except RuntimeError:
+            print(
+                "(SIGUSR1 task-dump: no running asyncio loop)",
+                file=sys.stderr,
+            )
+            return
+        print(
+            f"\n=== task-dump ({len(tasks)} tasks; SIGUSR1) ===",
+            file=sys.stderr,
+        )
+        for task in tasks:
+            name = (task.get_name() if hasattr(task, 'get_name')
+                    else 'unknown')
+            done = task.done()
+            print(
+                f"\n--- {name} done={done} cancelled={task.cancelled()} ---",
+                file=sys.stderr,
+            )
+            try:
+                task.print_stack(file=sys.stderr)
+            except Exception as e:
+                print(f"  (no stack: {e})", file=sys.stderr)
+        print("=== end task-dump ===\n", file=sys.stderr)
+        sys.stderr.flush()
+
+    signal.signal(signal.SIGUSR1, _dump)
+    print(
+        "(AIOMOQT_TASK_DUMP=1: SIGUSR1 will dump asyncio task stacks)",
+        file=sys.stderr,
+    )
+    return True

--- a/aiomoqt/versions.py
+++ b/aiomoqt/versions.py
@@ -1,0 +1,38 @@
+"""Version + build-info reporter for aiomoqt.
+
+Usage:
+    python -m aiomoqt.versions
+    aiomoqt-versions                     # console-script entry point
+
+Prints aiomoqt's installed version, plus the aiopquic version it's
+linked against and the picoquic / picotls submodule SHAs aiopquic
+was built from. Useful for diagnosing version-pair mismatches across
+the aiomoqt / aiopquic / picoquic stack.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from aiomoqt import __version__
+
+
+def print_versions(file=sys.stdout) -> None:
+    import aiomoqt
+    src = os.path.dirname(aiomoqt.__file__)
+    print(f"aiomoqt  {__version__}", file=file)
+    print(f"         {src}", file=file)
+    try:
+        from aiopquic import versions as _aiopquic_versions
+        _aiopquic_versions.print_versions(file=file)
+    except ImportError as e:
+        print(f"aiopquic (not importable: {e})", file=file)
+
+
+def main() -> int:
+    print_versions()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# moq-interop-runner entrypoint. Default role is the client; set
+# MOQT_ROLE=relay (matching the runner's docker-compose env) to start
+# the minimal interop relay on UDP/${MOQT_PORT:-4443}.
+set -eu
+
+case "${MOQT_ROLE:-client}" in
+    relay)
+        exec python -m aiomoqt.examples.moq_interop_relay \
+            --bind "${MOQT_BIND:-0.0.0.0}" \
+            --port "${MOQT_PORT:-4443}" \
+            --cert "${MOQT_CERT:-/certs/cert.pem}" \
+            --key  "${MOQT_KEY:-/certs/priv.key}" \
+            ${MOQT_QUIC:+--quic} \
+            ${MOQT_DRAFT:+--draft "$MOQT_DRAFT"} \
+            "$@"
+        ;;
+    client|*)
+        exec python -m aiomoqt.examples.moq_interop_client "$@"
+        ;;
+esac

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 Homepage = "https://github.com/gmarzot/aiomoqt"
 Repository = "https://github.com/gmarzot/aiomoqt.git"
 
+[project.scripts]
+aiomoqt-versions = "aiomoqt.versions:main"
+
 [project.optional-dependencies]
 test = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "certifi",
-    "aiopquic>=0.3.2",
+    "aiopquic>=0.3.3",
     "sortedcontainers>=2.4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "certifi",
-    "aiopquic>=0.3.3",
+    "aiopquic>=0.3.5",
     "sortedcontainers>=2.4.0",
 ]
 

--- a/tests/relays.json
+++ b/tests/relays.json
@@ -76,16 +76,6 @@
       "notes": "Cisco libquicr (server cert unacceptable → insecure)"
     },
     {
-      "name": "red5-moq",
-      "urls": {
-        "h3-wt": "https://moq-relay.red5.net:4433/moq"
-      },
-      "drafts": [14, 16],
-      "pub_mode": "publish",
-      "disabled_suites": ["relay-join", "relay-fetch", "relay-pub-sub"],
-      "notes": "Red5 Pro picoquic (endpoint /moq, not /moq-relay). ctrl-msg 6/6 clean on d14+d16; pub-sub subscribers get reset 0/3 — disabled pending investigation. Raw-quic endpoint moqt://moq-relay.red5.net:8443 is advertised in upstream registries but does not complete SETUP for us (ConnectionError) — unverified."
-    },
-    {
       "name": "moqtail",
       "urls": {
         "h3-wt": "https://relay.moqtail.dev"


### PR DESCRIPTION
## Headline

WT receiver bloat root-cause fix (the original release blocker). Pairs with aiopquic 0.3.5 which ships the RX-FC + observability counters that surfaced it.

## What changed

| commit | what it does |
|---|---|
| `07a6145` | **FIX: WT receiver bloat** — `_WTSessionMixin._on_event` no longer calls `super()._on_event` for translated events. Previously every `_EVT_WT_STREAM_DATA` was enqueued into a per-stream `asyncio.Queue` inside `WebTransportSession._stream_inbox` that aiomoqt never consumed, pinning the data memoryview (and underlying `aiopquic.StreamChunk`) forever. ~60K chunks/sec retention → 5-18 GB RSS in 30-60 s. Fix: skip `super()` for the event types we translate locally; only session-level events (ready/closed/draining/new_stream/tx_drained) go through the base handler. |
| `07a6145` | `_MOQTSessionMixin._dump_data_streams()` and `taskdump` SIGUSR2 wiring — per-session chain introspection (capacity, parse progress, group/object IDs). Tells you in one signal whether bytes are pinned at the chain layer or downstream. |
| `07a6145` | `loopback_bench` prints `transport: QUIC` or `H3/WebTransport` in its banner; `sub_bench` opt-in `AIOMOQT_TRACEMALLOC=1` for memory profiling. |
| `8e8ece7` | bump aiopquic dep floor \`>=0.3.3 → >=0.3.5\` (the 8-tuple \`drain_rx\` contract). |
| `c363e72` + `726b896` + `633ffef` + `c9e42a7` | CI test hardening: poll for pub_server ready (no fixed \`sleep 1.5\`), \`-u\` unbuffered output, bash watchdog around sub_bench, assertion reads interval table not summary block. Stops a flaky CI step from hanging the runner. |

## Validation

- **chunks_alive_total**: 2.3M → single digits during 60s sub_bench WT
- **RSS**: was 5-18 GB after 30-60s; now bounded
- **Throughput**: 2.3 Gbps steady (no change)
- **p99 latency**: was 384 ms (cliff) → 39 ms after fix
- aiopquic ≥0.3.5 enforced via dep floor

## Pairs with aiopquic 0.3.5

RX-FC hysteresis + per-cycle dedupe + counters / SIGUSR2 dump that made the bloat findable in seconds. See https://github.com/gmarzot/aiopquic/pull/13.

## Deferred to 0.9.6

- \`sub_bench -t\` doesn't reliably fire under bufferbloat (\`track.wait_closed(timeout=N)\` keeps running) — exposed by the CI hardening above
- Subscribe-stall unbounded growth (separate repro path; ~22 GB observed)
- Through-relay bottleneck (~700 Mbps bimodal)
