### PR TITLE
advertise draft-18, interop preference-probe + draft-18 follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@
   fields are the same varint pairs as d16's start/end and
   largest_group/object). Round-trip matrix tests added for both. This
   clears the d18 Fetch beta limitation noted under v0.10.0.
+- **Endpoint-keyed compat (interop client).** `moq_interop_client` now
+  auto-selects the opt-in tolerances a known relay needs, keyed by host, so
+  the moq-interop-runner (which passes only `RELAY_URL`, no per-column
+  `COMPAT`) gets the right behavior without per-column config. First entry:
+  the moq-rs draft-16 Cloudflare endpoint auto-enables `lenient-extensions`
+  (it emits a truncated trailing-extensions block on `SUBSCRIBE`/
+  `SUBSCRIBE_OK`), closing the cf-d16 pub-sub routing path. moq-rs advertises
+  no `IMPLEMENTATION` setup param, so recognition is by endpoint; explicit
+  `--compat` still adds to whatever the endpoint contributes. Default-off for
+  all other hosts (no global leniency).
 
 ## v0.10.0 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.10.1 (unreleased)
+
+- **Preference-ordered draft probe (interop client).** A single
+  `moq_interop_client` invocation now probes its `supported_drafts` in
+  preference order, pinning the first draft whose SETUP succeeds. One
+  manifest entry therefore prefers d16 against d16-capable relays yet still
+  reaches d18 against d18-only relays, with no d16→d18 regression. The
+  no-`--draft` default is the preference list `[16, 14, 18]`.
+- **draft-18 Fetch.** `FETCH` / `FETCH_OK` now speak the d18 wire: vi64
+  varints across the body, and `FETCH_OK` (a response) drops the in-band
+  Request ID per §10.1 — the same vi64 + request-id-gate shape as the other
+  OK replies, not a structural rewrite (the d18 "Location"/"End Location"
+  fields are the same varint pairs as d16's start/end and
+  largest_group/object). Round-trip matrix tests added for both. This
+  clears the d18 Fetch beta limitation noted under v0.10.0.
+
 ## v0.10.0 (unreleased)
 
 **draft-18 support (beta).** aiomoqt now speaks draft-18 alongside d14/d16,

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -120,17 +120,17 @@ def _format_exc(e: BaseException) -> str:
     return f"{cls}: {msg}" if cls not in msg else msg
 
 
-async def _auto_alpn_ok(host, port, path, use_quic, tls_disable_verify,
-                        debug, timeout: float = 5.0) -> bool:
-    """Probe whether the auto (multi-version) offer reaches SETUP. On raw
-    QUIC the client offers every version's ALPN newest-first; on WT it
-    advertises moqt-16 + a multi-version CLIENT_SETUP. A draft-14-only
-    relay that refuses the d16 offer — QUIC 376 no_application_protocol,
-    or a stalled WT SETUP that times out — fails here. Returns True iff
-    SETUP completes; a False (any handshake/SETUP failure) is the signal
-    to pin draft-14. Works for both transports."""
+async def _probe_setup_ok(host, port, path, use_quic, tls_disable_verify,
+                          debug, draft=None, timeout: float = 5.0) -> bool:
+    """Probe whether SETUP completes for a given offer. draft=None offers
+    the auto (multi-version) set; an int single-pins one draft (one ALPN)
+    — what the preference-ordered probe uses, so each attempt is
+    deterministic with no multi-offer server-choice vagary. A relay that
+    refuses the offer — QUIC 376 no_application_protocol, or a stalled /
+    timed-out WT SETUP — fails here. Returns True iff SETUP completes,
+    False on any handshake/SETUP failure. Works for both transports."""
     client = _make_client(host, port, path, use_quic,
-                          tls_disable_verify, debug, supported_drafts=None)
+                          tls_disable_verify, debug, supported_drafts=draft)
     try:
         async with asyncio.timeout(timeout):
             async with client.connect() as session:
@@ -937,10 +937,12 @@ def parse_args():
                         help="Enable debug logging to stderr")
     parser.add_argument(
         "--draft", type=parse_draft_spec,
-        default=(int(os.environ["DRAFT"])
-                 if os.environ.get("DRAFT", "").strip().isdigit() else None),
-        help="MoQT draft version, e.g. 14 or 16 (env: DRAFT). Default: "
-             "auto — multi-version ALPN with a draft-14 handshake fallback")
+        default=(parse_draft_spec(os.environ["DRAFT"])
+                 if os.environ.get("DRAFT", "").strip() else None),
+        help="MoQT draft, e.g. 16 (single = strict pin) or a comma list "
+             "16,14,18 (preference-ordered probe: pin the first whose SETUP "
+             "completes) (env: DRAFT). Default: auto multi-version ALPN with "
+             "a draft-14 handshake fallback")
     parser.add_argument(
         "--compat", type=str, default=os.environ.get("COMPAT", ""),
         help=(
@@ -995,7 +997,28 @@ async def run_tests(tests: list[str], host: str, port: int, path: str,
     # is untouched; the probe is a no-op against relays that negotiate
     # auto cleanly (it just adds one connect).
     effective_draft = supported_drafts
-    if supported_drafts is None and not await _auto_alpn_ok(
+    if isinstance(supported_drafts, (list, tuple)):
+        # Preference-ordered probe (e.g. --draft 16,14,18 / DRAFT=16,14,18):
+        # pin the FIRST draft whose single-ALPN SETUP completes. A
+        # d16-capable relay keeps d16 (preferred, stable); a d18-only relay
+        # falls through 16 -> 14 -> 18. Each attempt is a deterministic
+        # single-ALPN offer (no multi-offer server-choice vagary), so one
+        # manifest entry can prefer d16 everywhere yet still succeed at d18
+        # against d18-only relays — with no d16->d18 regression on relays
+        # whose d18 diverges (e.g. moq-dev).
+        effective_draft = None
+        for d in supported_drafts:
+            if await _probe_setup_ok(host, port, path, use_quic,
+                                     tls_disable_verify, debug, draft=d):
+                effective_draft = d
+                reporter.notes.append(f"preference probe pinned draft-{d}")
+                break
+        if effective_draft is None:
+            effective_draft = supported_drafts[-1]
+            reporter.notes.append(
+                "preference probe: no offered draft reached SETUP; "
+                f"trying draft-{effective_draft}")
+    elif supported_drafts is None and not await _probe_setup_ok(
             host, port, path, use_quic, tls_disable_verify, debug):
         effective_draft = 14
         reporter.notes.append(

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -98,9 +98,35 @@ KNOWN_COMPAT_IMPLS = frozenset({
     "all",                # enable every known compat tolerance
 })
 
+# moq-rs advertises NO implementation name in its SERVER_SETUP (it sets only
+# MAX_REQUEST_ID), so compat can't be keyed off a wire-advertised identity.
+# Instead, recognize a known moq-rs interop endpoint by host and self-enable
+# the tolerances that implementation needs. The moq-interop-runner invokes
+# the client with only RELAY_URL (no per-column COMPAT), so a single image
+# must self-select; these are the same opt-in keys as --compat, just
+# endpoint-derived.
+RELAY_COMPAT = {
+    # itzmanish/moq-rs draft-16 fork (Cloudflare interop endpoint): emits a
+    # truncated trailing-extensions KVP block on SUBSCRIBE / SUBSCRIBE_OK.
+    "draft-16-manish.cloudflare.mediaoverquic.com": frozenset({"lenient-extensions"}),
+}
+
 
 def _compat_active(compat: frozenset, key: str) -> bool:
     return "all" in compat or key in compat
+
+
+def _relay_compat(host: str) -> frozenset:
+    """Compat tolerances auto-selected for a known relay endpoint (host
+    substring match). Lets one client image recognize a quirky relay and
+    self-enable the matching opt-in tolerance with no per-column config,
+    since the moq-interop-runner passes only RELAY_URL."""
+    h = (host or "").lower()
+    keys = set()
+    for needle, ks in RELAY_COMPAT.items():
+        if needle in h:
+            keys |= ks
+    return frozenset(keys)
 
 
 def _format_exc(e: BaseException) -> str:
@@ -1078,6 +1104,17 @@ def main():
 
     host, port, path, use_quic = parse_relay_url(args.relay)
     compat = parse_compat(args.compat)
+    # Auto-select endpoint-keyed tolerances (e.g. moq-rs-d16's truncated
+    # trailing-extensions) so the runner needs no per-column COMPAT. Explicit
+    # --compat still adds to whatever the endpoint contributes.
+    relay_compat = _relay_compat(host)
+    if relay_compat - compat:
+        print(
+            f"# Compat (auto for {host}): "
+            f"{','.join(sorted(relay_compat - compat))}",
+            file=sys.stderr,
+        )
+    compat = compat | relay_compat
 
     # Plumb the wire-tolerance flag into the deserializer module
     # before any session is created. Without this the parser stays

--- a/aiomoqt/examples/moq_interop_client.py
+++ b/aiomoqt/examples/moq_interop_client.py
@@ -1100,7 +1100,14 @@ def main():
 
     # Public API takes the draft NUMBER (14, 16, ...). MOQTClient
     # normalizes to the wire form internally; pass args.draft through.
-    supported_drafts = args.draft if args.draft else None
+    # No explicit draft (the moq-interop-runner invokes us with RELAY_URL
+    # but no DRAFT) defaults to the preference-ordered probe 16->14->18:
+    # pin d16 for d16-capable relays, fall through to d14, and reach d18
+    # only for d18-only relays. Deterministic single-ALPN per probe — one
+    # client image negotiates the best draft per relay with no manifest
+    # per-column config. An explicit --draft/DRAFT single int still pins
+    # strictly; an explicit list sets a custom probe order.
+    supported_drafts = args.draft if args.draft is not None else [16, 14, 18]
 
     if args.verbose:
         transport = "QUIC" if use_quic else "WebTransport"

--- a/aiomoqt/messages/fetch.py
+++ b/aiomoqt/messages/fetch.py
@@ -49,14 +49,14 @@ class Fetch(MOQTMessage):
         self.type = MOQTMessageType.FETCH
 
     def serialize(self, *, prof: DraftProfile) -> Buffer:
-        buf = Buffer(capacity=BUF_SIZE)
-        payload = Buffer(capacity=BUF_SIZE)
+        buf = Buffer(capacity=BUF_SIZE, vi64=prof.vi64)
+        payload = Buffer(capacity=BUF_SIZE, vi64=prof.vi64)
 
-        payload.push_uint_var(self.request_id)
+        payload.push_vint(self.request_id)
 
         if is_draft16_or_later(prof.draft):
             # d16: priority and group_order live in params
-            payload.push_uint_var(self.fetch_type)
+            payload.push_vint(self.fetch_type)
         else:
             # d14: priority and group_order are mandatory fixed fields (no
             # optional form like d16's params) — substitute defaults when
@@ -66,22 +66,22 @@ class Fetch(MOQTMessage):
             payload.push_uint8(self.group_order
                                if self.group_order is not None
                                else GroupOrder.ASCENDING)
-            payload.push_uint_var(self.fetch_type)
+            payload.push_vint(self.fetch_type)
 
         if self.fetch_type == FetchType.STANDALONE:
-            payload.push_uint_var(len(self.namespace))
+            payload.push_vint(len(self.namespace))
             for part in self.namespace:
-                payload.push_uint_var(len(part))
+                payload.push_vint(len(part))
                 payload.push_bytes(part)
-            payload.push_uint_var(len(self.track_name))
+            payload.push_vint(len(self.track_name))
             payload.push_bytes(self.track_name)
-            payload.push_uint_var(self.start_group)
-            payload.push_uint_var(self.start_object)
-            payload.push_uint_var(self.end_group)
-            payload.push_uint_var(self.end_object)
+            payload.push_vint(self.start_group)
+            payload.push_vint(self.start_object)
+            payload.push_vint(self.end_group)
+            payload.push_vint(self.end_object)
         elif _is_joining(self.fetch_type):
-            payload.push_uint_var(self.joining_request_id)
-            payload.push_uint_var(self.joining_start)
+            payload.push_vint(self.joining_request_id)
+            payload.push_vint(self.joining_start)
         else:
             raise ValueError(
                 f"Invalid fetch_type: {self.fetch_type} "
@@ -97,7 +97,7 @@ class Fetch(MOQTMessage):
         else:
             MOQTMessage._serialize_params(payload, self.parameters, prof=prof)
 
-        buf.push_uint_var(self.type)
+        buf.push_vint(self.type)
         buf.push_uint16(payload.tell())
         buf.push_bytes(payload.data)
         return buf
@@ -115,31 +115,31 @@ class Fetch(MOQTMessage):
         subscriber_priority = 128
         group_order = GroupOrder.DESCENDING
 
-        request_id = buf.pull_uint_var()
+        request_id = buf.pull_vint()
 
         if is_draft16_or_later(prof.draft):
-            fetch_type = buf.pull_uint_var()
+            fetch_type = buf.pull_vint()
         else:
             subscriber_priority = buf.pull_uint8()
             group_order = buf.pull_uint8()
-            fetch_type = buf.pull_uint_var()
+            fetch_type = buf.pull_vint()
 
         if fetch_type == FetchType.STANDALONE:
             ns = []
-            ns_len = buf.pull_uint_var()
+            ns_len = buf.pull_vint()
             for _ in range(ns_len):
-                part_len = buf.pull_uint_var()
+                part_len = buf.pull_vint()
                 ns.append(buf.pull_bytes(part_len))
             namespace = tuple(ns)
-            track_name_len = buf.pull_uint_var()
+            track_name_len = buf.pull_vint()
             track_name = buf.pull_bytes(track_name_len)
-            start_group = buf.pull_uint_var()
-            start_object = buf.pull_uint_var()
-            end_group = buf.pull_uint_var()
-            end_object = buf.pull_uint_var()
+            start_group = buf.pull_vint()
+            start_object = buf.pull_vint()
+            end_group = buf.pull_vint()
+            end_object = buf.pull_vint()
         elif _is_joining(fetch_type):
-            joining_request_id = buf.pull_uint_var()
-            joining_start = buf.pull_uint_var()
+            joining_request_id = buf.pull_vint()
+            joining_start = buf.pull_vint()
         else:
             raise ValueError(
                 f"Invalid fetch_type: {fetch_type} "
@@ -192,16 +192,19 @@ class FetchOk(MOQTMessage):
             self.parameters = {}
 
     def serialize(self, *, prof: DraftProfile) -> bytes:
-        buf = Buffer(capacity=BUF_SIZE)
-        payload = Buffer(capacity=BUF_SIZE)
+        buf = Buffer(capacity=BUF_SIZE, vi64=prof.vi64)
+        payload = Buffer(capacity=BUF_SIZE, vi64=prof.vi64)
 
-        payload.push_uint_var(self.request_id)
+        # FETCH_OK is a response (§10.1): d18 omits the Request ID (demuxed
+        # by the request stream; the dispatcher injects it on parse).
+        if prof.reply_has_request_id:
+            payload.push_vint(self.request_id)
 
         if is_draft16_or_later(prof.draft):
             # d16: no group_order fixed field
             payload.push_uint8(self.end_of_track)
-            payload.push_uint_var(self.largest_group_id)
-            payload.push_uint_var(self.largest_object_id)
+            payload.push_vint(self.largest_group_id)
+            payload.push_vint(self.largest_object_id)
             params = dict(self.parameters)
             if self.group_order is not None:
                 params[ParamType.GROUP_ORDER] = self.group_order
@@ -211,11 +214,11 @@ class FetchOk(MOQTMessage):
             # d14: group_order as fixed field
             payload.push_uint8(self.group_order)
             payload.push_uint8(self.end_of_track)
-            payload.push_uint_var(self.largest_group_id)
-            payload.push_uint_var(self.largest_object_id)
+            payload.push_vint(self.largest_group_id)
+            payload.push_vint(self.largest_object_id)
             MOQTMessage._serialize_params(payload, self.parameters, prof=prof)
 
-        buf.push_uint_var(self.type)
+        buf.push_vint(self.type)
         buf.push_uint16(payload.tell())
         buf.push_bytes(payload.data)
         return buf
@@ -225,13 +228,14 @@ class FetchOk(MOQTMessage):
         # buf_end is the absolute end-of-message position derived from
         # the outer frame length. Required for d16 (Track Extensions
         # have no length prefix; sequence runs to end of message).
-        request_id = buf.pull_uint_var()
+        request_id = (buf.pull_vint()
+                      if prof.reply_has_request_id else None)
         track_extensions = None
 
         if is_draft16_or_later(prof.draft):
             end_of_track = buf.pull_uint8()
-            largest_group_id = buf.pull_uint_var()
-            largest_object_id = buf.pull_uint_var()
+            largest_group_id = buf.pull_vint()
+            largest_object_id = buf.pull_vint()
             params = MOQTMessage._deserialize_params(buf, prof=prof, buf_end=buf_end)
             group_order = params.pop(ParamType.GROUP_ORDER, GroupOrder.DESCENDING)
             track_extensions = MOQTMessage._extensions_decode(
@@ -239,8 +243,8 @@ class FetchOk(MOQTMessage):
         else:
             group_order = buf.pull_uint8()
             end_of_track = buf.pull_uint8()
-            largest_group_id = buf.pull_uint_var()
-            largest_object_id = buf.pull_uint_var()
+            largest_group_id = buf.pull_vint()
+            largest_object_id = buf.pull_vint()
             params = MOQTMessage._deserialize_params(buf, prof=prof, buf_end=buf_end)
 
         return cls(
@@ -267,14 +271,14 @@ class FetchError(MOQTMessage):
         buf = Buffer(capacity=BUF_SIZE)
         payload = Buffer(capacity=BUF_SIZE)
 
-        payload.push_uint_var(self.request_id)
-        payload.push_uint_var(self.error_code)
+        payload.push_vint(self.request_id)
+        payload.push_vint(self.error_code)
         
         reason_bytes = self.reason.encode()
-        payload.push_uint_var(len(reason_bytes))
+        payload.push_vint(len(reason_bytes))
         payload.push_bytes(reason_bytes)
 
-        buf.push_uint_var(self.type)
+        buf.push_vint(self.type)
         buf.push_uint16(payload.tell())
         buf.push_bytes(payload.data)
         return buf
@@ -282,9 +286,9 @@ class FetchError(MOQTMessage):
     @classmethod
     def deserialize(cls, buf: Buffer, *, prof: DraftProfile, buf_end: Optional[int] = None) -> 'FetchError':
 
-        request_id = buf.pull_uint_var()
-        error_code = buf.pull_uint_var()
-        reason_len = buf.pull_uint_var()
+        request_id = buf.pull_vint()
+        error_code = buf.pull_vint()
+        reason_len = buf.pull_vint()
         reason = buf.pull_bytes(reason_len).decode()
 
         return cls(
@@ -305,9 +309,9 @@ class FetchCancel(MOQTMessage):
         buf = Buffer(capacity=BUF_SIZE)
         payload = Buffer(capacity=BUF_SIZE)
 
-        payload.push_uint_var(self.request_id)
+        payload.push_vint(self.request_id)
 
-        buf.push_uint_var(self.type)
+        buf.push_vint(self.type)
         buf.push_uint16(payload.tell())
         buf.push_bytes(payload.data)
         return buf
@@ -315,6 +319,6 @@ class FetchCancel(MOQTMessage):
     @classmethod
     def deserialize(cls, buf: Buffer, *, prof: DraftProfile, buf_end: Optional[int] = None) -> 'FetchCancel':
 
-        request_id = buf.pull_uint_var()
+        request_id = buf.pull_vint()
 
         return cls(request_id=request_id)

--- a/aiomoqt/tests/test_messages.py
+++ b/aiomoqt/tests/test_messages.py
@@ -1088,8 +1088,9 @@ class TestDraft18ControlMessages:
     *replies* (it is demuxed from the request stream and injected by the
     dispatcher at runtime, so it is absent on the wire here — hence
     skip_fields={'request_id'} on the replies). SETUP is the symmetric
-    d18 message (0x2F00). d18 Fetch is pending (beta), so FETCH/FETCH_OK
-    are intentionally not covered.
+    d18 message (0x2F00). FETCH/FETCH_OK follow the same vi64 +
+    request-id-gate pattern (the d18 "Location"/"End Location" fields are
+    the same varint pairs as d16's start/end and largest_group/object).
     """
 
     D18 = MOQT_VERSION_DRAFT18
@@ -1281,6 +1282,46 @@ class TestDraft18ControlMessages:
              'parameters': {}},
             type_id=D18MessageType.SUBSCRIBE_NAMESPACE,
             version=self.D18,
+        )
+
+    # ---- FETCH (request) / FETCH_OK (reply: drops Request ID) ----
+    def test_fetch_d18(self):
+        assert moqt_message_serialization_versioned(
+            Fetch,
+            {
+                'request_id': 42,
+                'fetch_type': FetchType.STANDALONE,
+                'namespace': (b'live', b'sports'),
+                'track_name': b'football',
+                'subscriber_priority': 1,
+                'group_order': GroupOrder.ASCENDING,
+                'start_group': 10, 'start_object': 5,
+                'end_group': 20, 'end_object': 15,
+                'parameters': {},
+            },
+            type_id=MOQTMessageType.FETCH,
+            version=self.D18,
+        )
+
+    def test_fetch_ok_d18(self):
+        # FETCH_OK is a response → d18 omits request_id; the d18 "End
+        # Location" is the same two varints as largest_group/object, and
+        # group_order rides in params — i.e. the same vi64 + request-id-gate
+        # shape as the other OK replies, not a structural rewrite.
+        assert moqt_message_serialization_versioned(
+            FetchOk,
+            {
+                'request_id': 42,
+                'group_order': GroupOrder.ASCENDING,
+                'end_of_track': 0,
+                'largest_group_id': 50,
+                'largest_object_id': 200,
+                'parameters': {},
+                'track_extensions': {},
+            },
+            type_id=MOQTMessageType.FETCH_OK,
+            version=self.D18,
+            skip_fields={'request_id', 'track_extensions'},
         )
 
 

--- a/tests/relays.json
+++ b/tests/relays.json
@@ -108,6 +108,39 @@
       "compat": ["lenient-extensions"],
       "disabled_suites": ["relay-join", "relay-fetch"],
       "notes": "Cloudflare moq-rs draft-16 interop branch. compat=lenient-extensions: this fork emits a truncated trailing-extensions KVP block on SubscribeOk (kvp_start=6 tell=7 exts_end=7) which our strict parser rejects as non-compliant; tolerated + annotated, recovering ctrl-msg to 6/6. relay-join + relay-fetch disabled (#24): verified unsupported — itzmanish/moq-rs README also lists FETCH 'Not Soon', and the relay never answers JOIN/FETCH (TimeoutError; join is a joining-fetch). pub-sub[publish] kept as a genuine fail; root-caused 2026-06-21 to two layers: (A) [our side, FIXED] with pub_mode=publish-both the namespace resolves, but the relay's SubscribeOk carries the same truncated trailing-extensions block as its ctrl-msg path, which crashed the multi_sub_bench subscriber (the lenient-extensions tolerance lived only in moq_interop_client, not the bench) — now plumbed via `multi_sub_bench --compat lenient-extensions`; (B) [relay side, confirmed] even with control fully working and the publisher sending 300+ objects, the relay forwards ZERO to subscribers. Ruled out on our side via live tests + spec §10.1: forward=0 and forward=1, alias-matched and alias-diverged all give 0 objects, and the relay never RESETs our data streams (track_alias has no parity rule, only session-uniqueness, which we satisfy). With bare pub_mode=publish the surface symptom is code=4 'Track not found' (relay never got PUB_NS). The same flow delivers objects vs moxygen/imquic/cloudflare-d14, so (B) is a moq-rs d16-fork forwarding bug. Upstream also advertises an H3/WT endpoint at https://.../moq but our client hits a SETUP parse error (\"Read out of bounds\") — QUIC only here until that's resolved."
+    },
+    {
+      "name": "fb-mvfst-d18",
+      "urls": {
+        "raw-quic": "moqt://fb.mvfst.net:9448",
+        "h3-wt":    "https://fb.mvfst.net:9448/moq-relay"
+      },
+      "drafts": [18],
+      "pub_mode": "publish",
+      "disabled_suites": [],
+      "notes": "Upstream moxygen/mvfst reference at draft-18 — the conformant d18 reference (control 6/6 over raw-QUIC, 2026-06-22). Separate row from moxygen-fb, which stays d14/d16."
+    },
+    {
+      "name": "nokia-d18",
+      "urls": {
+        "raw-quic": "moqt://moqt.nokiaresearch.com:4443/moq",
+        "h3-wt":    "https://moqt.nokiaresearch.com:4443/moq"
+      },
+      "drafts": [18],
+      "pub_mode": "publish",
+      "disabled_suites": [],
+      "notes": "Nokia Research draft-18 relay (independent impl). ~5/6: announce-subscribe fails relay-side (the reference moq-dev-rs client also fails it there), not an aiomoqt issue."
+    },
+    {
+      "name": "cf-d18-interop",
+      "urls": {
+        "raw-quic": "moqt://draft-18-interop.cloudflare.mediaoverquic.com:443",
+        "h3-wt":    "https://draft-18-interop.cloudflare.mediaoverquic.com:443/moq"
+      },
+      "drafts": [18],
+      "pub_mode": "publish-both",
+      "disabled_suites": [],
+      "notes": "Cloudflare moq-rs draft-18-dev. Setup OK; announce/subscribe fail relay-side — moq-rs draft-18-dev has no accept_bi, so it never reads the per-request bidirectional request streams IETF d18 §3 mandates (verified against a locally-built relay + mlog). Kept as a documented relay-side failure rather than masked."
     }
   ]
 }


### PR DESCRIPTION
0.10.1 — draft-18 follow-ups + interop hardening on top of the 0.10.0 beta. All d14/d16 behavior preserved; changes are additive.

## Included
- **Preference-ordered draft probe (interop client).** No-`--draft` default probes `[16, 14, 18]`, single-ALPN SETUP each, pinning the first that completes. One image prefers draft-16 against draft-16-capable relays, still reaches draft-18-only relays, stays deterministic (no multi-offer server-choice ambiguity), and has no draft-16→draft-18 regression. (8766a48, 04dfe9e)
- **draft-18 Fetch.** `FETCH` / `FETCH_OK` now speak the draft-18 wire: vi64 body, and `FETCH_OK` (a response) drops the in-band Request ID per §10.1 — the same gate as the other OK replies, not a structural rewrite. Round-trip matrix tests for both. (8e3ad2f)
- **Endpoint-keyed compat (interop client).** `moq_interop_client` auto-selects a known relay's opt-in tolerances keyed by host (the moq-interop-runner passes only `RELAY_URL`, no per-column `COMPAT`). First entry: the moq-rs draft-16 Cloudflare endpoint auto-enables `lenient-extensions` (it emits a truncated trailing-extensions block on `SUBSCRIBE`/`SUBSCRIBE_OK`), closing the cf-d16 pub-sub control path. moq-rs advertises no `IMPLEMENTATION` setup param, so recognition is by endpoint; default-off for all other hosts. (1839a13)

Pairs with upstream englishm/moq-interop-runner#88 (advertise draft-18 in aiomoqt's `draft_versions`).

## Root-caused this cycle (both relay-side, not aiomoqt)
- **moq-rs draft-18 announce gap** — moq-rs draft-18-dev has no `accept_bi`; it reads requests inline on the unidirectional control stream instead of the per-request bidirectional streams IETF draft-18 §3 mandates (which aiomoqt opens and mvfst accepts). Confirmed against a locally-built relay + mlog. Cannot be fixed client-side without breaking conformance against mvfst.
- **moq-rs draft-16 pub-sub** — two layers: (A) the truncated trailing-extensions parse, closed here by endpoint-keyed `lenient-extensions`; (B) moq-rs forwards zero objects even with control working — relay-side, confirmed; the runner's control-plane testcases don't exercise object delivery.

## Follow-up
- [ ] interop-client test calibration (align scenario assertions with reference clients' lenient-ok/skip semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
