### PR TITLE
0.10.2: draft-18 FETCH/joining-FETCH/FETCH_OK route on the request bidi stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.10.2 (unreleased)
+
+- **draft-18 FETCH / joining-FETCH / FETCH_OK now use the request stream.**
+  `fetch()`, the joining-fetch helper, and `fetch_ok()` were sending on the
+  single control stream. At draft-18 every request opener must open its own
+  bidirectional request stream (and its response returns on that stream), so
+  current moxygen rejected a FETCH on the control stream with a
+  PROTOCOL_VIOLATION right after SETUP. These paths now route through
+  `_send_request` / `_send_reply` like SUBSCRIBE/PUBLISH. Verified live against
+  a draft-18 moxygen relay: control 6/6 + `fetch` + `join` all pass. Pre-d18
+  is unchanged (those routes fall back to the control stream). The d18
+  parameter encoding (uint8 SUBSCRIBER_PRIORITY/GROUP_ORDER/FORWARD per
+  §10.2.7/8/12) was already correct — the bug was purely the send path.
+
 ## v0.10.1 (unreleased)
 
 - **Preference-ordered draft probe (interop client).** A single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   is unchanged (those routes fall back to the control stream). The d18
   parameter encoding (uint8 SUBSCRIBER_PRIORITY/GROUP_ORDER/FORWARD per
   §10.2.7/8/12) was already correct — the bug was purely the send path.
+- **Known limitation (draft-18 pub-sub object delivery).** Control, FETCH, and
+  JOIN interop at d18; object *delivery* does not yet — a publisher ends the
+  publish at the `forward=1` trigger before streaming objects, so subscribers
+  receive 0 objects. Tracked for 0.10.3. d14/d16 pub-sub is unaffected.
 
 ## v0.10.1 (unreleased)
 

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -1949,7 +1949,7 @@ class _MOQTSessionMixin:
         # peers can't resolve them before our awaiter registers.
         self._pending_requests[sub_request_id] = self._loop.create_future()
         logger.info(f"MOQT send: {sub_msg}")
-        self.send_control_message(sub_msg)
+        self._send_request(sub_request_id, sub_msg)
 
         fetch_request_id = self._allocate_request_id()
         fetch_msg = Fetch(
@@ -1968,7 +1968,7 @@ class _MOQTSessionMixin:
         self._fetch_done_futures[fetch_request_id] = \
             self._loop.create_future()
         logger.info(f"MOQT send: {fetch_msg}")
-        self.send_control_message(fetch_msg)
+        self._send_request(fetch_request_id, fetch_msg)
 
         if not wait_response:
             return (sub_msg, fetch_msg)
@@ -2021,7 +2021,10 @@ class _MOQTSessionMixin:
         self._fetch_done_futures[request_id] = \
             self._loop.create_future()
         logger.info(f"MOQT send: {message}")
-        self.send_control_message(message)
+        # FETCH is a request opener: at d18 it must open its own bidi
+        # request stream (like SUBSCRIBE/PUBLISH); pre-d18 _send_request
+        # falls back to the single control stream.
+        self._send_request(request_id, message)
 
         if not wait_response:
             return message
@@ -2048,7 +2051,9 @@ class _MOQTSessionMixin:
             track_extensions=track_extensions or {},
         )
         logger.info(f"MOQT send: {message}")
-        self.send_control_message(message)
+        # FETCH_OK is a response: at d18 it returns on the request's own
+        # bidi stream; pre-d18 _send_reply falls back to the control stream.
+        self._send_reply(request_id, message)
         return message
 
     def fetch_error(


### PR DESCRIPTION
## 0.10.2 — draft-18 FETCH on the request stream

`fetch()`, the joining-fetch helper, and `fetch_ok()` were sending on the single control stream. At draft-18 every request opener must open its own **bidirectional request stream** (and its response returns on that stream) — so current moxygen rejected a FETCH-on-control with `PROTOCOL_VIOLATION` immediately after SETUP. Only these three paths missed it; `subscribe`/`publish`/`publish_namespace` already routed correctly.

Routed them through `_send_request` / `_send_reply` like the other request openers. Pre-d18 is unchanged (those routes fall back to the control stream).

### Verified live against a current draft-18 moxygen relay
- control scenarios **6/6** (setup-only, announce-only, publish-namespace-done, subscribe-error, announce-subscribe, subscribe-before-announce)
- `fetch` ✓ and `join` (joining fetch) ✓ — now return a normal `FETCH_ERROR` instead of terminating the connection
- **268 unit/loopback tests green**

### Notes
- The d18 parameter encoding (uint8 SUBSCRIBER_PRIORITY/GROUP_ORDER/FORWARD, §10.2.7/8/12) was already correct — the earlier "vi64" lead came from a bug in the moqx `moq_decode.py` debug tool (openmoq/moqx#430, PR #431), not our wire.
- Remaining d18 item (separate): pub-sub object-delivery fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
