### PR TITLE
0.10.3: draft-18 REQUEST_UPDATE drops Existing Request ID (fixes d18 pub-sub object delivery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.10.3 (unreleased)
+
+- **draft-18 pub-sub object delivery fixed (REQUEST_UPDATE wire format).**
+  draft-18 removed the `Existing Request ID` field from `REQUEST_UPDATE`
+  (§10.9, Figure 12); draft-16 still carries it. Our `RequestUpdate` decoder
+  read that field unconditionally, so when a subscriber arrived and the relay
+  sent the *publisher* a `forward=1` `REQUEST_UPDATE`, the extra varint shifted
+  the parse and a delta-coded parameter key byte was misread as a parameter
+  length — a PROTOCOL_VIOLATION that closed the publisher session, which pruned
+  the namespace and left every subscriber with "no such namespace" and 0
+  objects. `existing_request_id` is now draft-gated (kept for d16, omitted for
+  d18+ per the spec). This resolves the draft-18 pub-sub known limitation noted
+  in v0.10.2. Verified live against a draft-18 moxygen relay across all four
+  corners (d16/d18 × raw-QUIC / WebTransport): 3/3 subscribers, objects
+  delivered. d14/d16 pub-sub is unchanged.
+
 ## v0.10.2 (unreleased)
 
 - **draft-18 FETCH / joining-FETCH / FETCH_OK now use the request stream.**

--- a/aiomoqt/messages/request.py
+++ b/aiomoqt/messages/request.py
@@ -114,8 +114,11 @@ class RequestUpdate(MOQTMessage):
     Replaces SUBSCRIBE_UPDATE. Now applies to all request types and
     gets an acknowledgment (REQUEST_OK/REQUEST_ERROR).
 
-    Wire format: Request ID (i), Existing Request ID (i),
-                 Num Parameters (i), Parameters (..) ...
+    Wire format (d16): Request ID (i), Existing Request ID (i),
+                       Num Parameters (i), Parameters (..) ...
+    Wire format (d18): Request ID (i), Num Parameters (i),
+                       Parameters (..) ...  (Existing Request ID removed
+                       per §10.9 Figure 12)
     """
     request_id: int = None
     existing_request_id: int = None
@@ -128,11 +131,12 @@ class RequestUpdate(MOQTMessage):
         buf = Buffer(capacity=BUF_SIZE)
         payload = Buffer(capacity=BUF_SIZE, vi64=prof.vi64)
 
-        # REQUEST_UPDATE carries both a (new) Request ID and the Existing
-        # Request ID it updates, in d16 and d18 alike — confirmed against
-        # the mvfst/moxygen d18 relay, which sends both. d18 uses vi64.
+        # d16 REQUEST_UPDATE carries the Existing Request ID it updates;
+        # d18 (§10.9 Figure 12) removed that field. Request ID is always
+        # present. d18 uses vi64.
         payload.push_vint(self.request_id)
-        payload.push_vint(self.existing_request_id)
+        if prof.draft < 18:
+            payload.push_vint(self.existing_request_id)
         MOQTMessage._serialize_params(payload, self.parameters or {}, prof=prof)
 
         buf.push_uint_var(self.type)
@@ -143,7 +147,7 @@ class RequestUpdate(MOQTMessage):
     @classmethod
     def deserialize(cls, buf: Buffer, *, prof: DraftProfile, buf_end: Optional[int] = None) -> 'RequestUpdate':
         request_id = buf.pull_vint()
-        existing_request_id = buf.pull_vint()
+        existing_request_id = (buf.pull_vint() if prof.draft < 18 else None)
         params = MOQTMessage._deserialize_params(buf, prof=prof, buf_end=buf_end)
 
         return cls(

--- a/aiomoqt/tests/test_d18_dispatch_tier.py
+++ b/aiomoqt/tests/test_d18_dispatch_tier.py
@@ -156,12 +156,15 @@ def test_d18_replies_omit_request_id():
     e18 = bytes(RequestError(request_id=9, error_code=1, reason="x").serialize(prof=profile_for(18)).data)
     assert len(e18) < len(e16)
 
-    # RequestUpdate carries BOTH Request ID and Existing Request ID in d18
-    # (confirmed against the mvfst/moxygen relay); d18 just uses vi64.
+    # d18 (§10.9 Figure 12) dropped Existing Request ID from REQUEST_UPDATE;
+    # d16 still carries it. The d18 wire must omit it (shorter than d16) and
+    # round-trip with no Existing Request ID.
+    u16 = bytes(RequestUpdate(request_id=9, existing_request_id=7, parameters={}).serialize(prof=profile_for(16)).data)
     u18 = bytes(RequestUpdate(request_id=9, existing_request_id=7, parameters={}).serialize(prof=profile_for(18)).data)
+    assert len(u18) < len(u16)
     ru = RequestUpdate.deserialize(Buffer(data=u18[3:]), prof=profile_for(18), buf_end=len(u18) - 3)
     assert ru.request_id == 9
-    assert ru.existing_request_id == 7
+    assert ru.existing_request_id is None
 
 
 def test_d18_typed_param_values_are_uint8():
@@ -243,18 +246,17 @@ def test_d16_nonuint8_even_param_large_value_is_rfc9000():
 def test_d18_request_update_large_ids_round_trip_vi64():
     # RequestUpdate ids go through the buffer's push_vint. With values >= 64
     # the vi64 vs RFC9000 forms diverge, so this confirms the payload buffer
-    # was tagged vi64: request_id 100 -> 0x64 (1B), existing 200 -> 0x80C8.
+    # was tagged vi64. d18 dropped Existing Request ID (§10.9), so the vi64
+    # check rides Request ID: 200 -> 0x80C8 (vi64) vs 0x40C8 (RFC9000).
     from aiomoqt.messages.request import RequestUpdate
     raw = bytes(RequestUpdate(
-        request_id=100, existing_request_id=200,
-        parameters={}).serialize(prof=profile_for(18)).data)
+        request_id=200, parameters={}).serialize(prof=profile_for(18)).data)
     body = raw[3:]  # after type (1B, 0x02) + 16-bit Length
-    assert body[0] == 0x64
-    assert body[1:3] == bytes([0x80, 0xC8])
+    assert body[0:2] == bytes([0x80, 0xC8])
     ru = RequestUpdate.deserialize(
         Buffer(data=body, vi64=True), prof=profile_for(18), buf_end=len(body))
-    assert ru.request_id == 100
-    assert ru.existing_request_id == 200
+    assert ru.request_id == 200
+    assert ru.existing_request_id is None
 
 
 def test_d18_publish_namespace_large_request_id_vi64():

--- a/aiomoqt/tests/test_messages.py
+++ b/aiomoqt/tests/test_messages.py
@@ -1232,7 +1232,7 @@ class TestDraft18ControlMessages:
         # param-value codec path, not the varint one.
         assert moqt_message_serialization_versioned(
             RequestUpdate,
-            {'request_id': 10, 'existing_request_id': 5,
+            {'request_id': 10,
              'parameters': {ParamType.FORWARD: 1}},
             type_id=D16MessageType.REQUEST_UPDATE,
             version=self.D18,


### PR DESCRIPTION
## draft-18 pub-sub object delivery (0.10.3)

Fixes the draft-18 pub-sub known limitation recorded in 0.10.2.

**Root cause (spec-confirmed).** draft-18 §10.9 (Figure 12) removed the `Existing Request ID` field from `REQUEST_UPDATE`; draft-16 still carries it. Our `RequestUpdate` decoder read it unconditionally. When a subscriber arrives, the relay flips `forward=1` and sends the *publisher* a `REQUEST_UPDATE`; at d18 the extra `pull_vint()` ate the parameter-count byte, shifting the parse so a delta-coded parameter **key** byte (`0x11`=17) was read as a parameter **length** → `parameter length 17 exceeds remaining 13` → `PROTOCOL_VIOLATION` → the publisher session closes → moxygen prunes the namespace → every subscriber gets `no such namespace or track` and 0 objects. d16 worked precisely because the field genuinely exists there.

**Fix.** Draft-gate `existing_request_id` in `RequestUpdate.serialize`/`deserialize` (kept for d16, omitted for d18+). The dataclass field is retained. Two tests in `test_d18_dispatch_tier.py` plus the d18 case in `test_messages.py` had encoded the buggy layout and were realigned to the spec.

**Verification.**
- 268 unit tests green
- Live against a draft-18 moxygen relay, all four corners (d16/d18 × raw-QUIC / WebTransport): **3/3 subscribers, objects delivered** (was 1/3, 0 objects at d18)
- Relay XLOG confirms objects cached and forwarded to all 3 subscribers
- d14/d16 pub-sub unchanged (d16 regression-checked: 3/3 + objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)