### PR TITLE
0.10.4: cross-draft (d14/d16/d18) microbenches + local-aiopquic dev docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
   `>0` = loop), replacing `--once`. Each result line echoes the full
   transport-appropriate URL
   (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
-  probe is reported on that one line with its error code; the underlying
-  handshake WARNING/ERROR logs appear only under `--debug`.
+  probe is reported on that one line as a short conclusion (e.g. "no compatible
+  draft (no shared ALPN/version)"); the raw error + handshake WARNING/ERROR logs
+  appear only under `--debug`.
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,12 @@
   probed **each individually, in order**; **`--offer`** instead offers the whole
   list in one session and reports the draft the relay negotiates. Looping is now
   controlled solely by **`--interval`** (`0` = probe once and exit [default],
-  `>0` = loop), replacing `--once`. Each result line echoes the full
-  transport-appropriate URL
-  (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
-  probe is reported on that one line as a short `status - reason` conclusion
-  (e.g. `connection refused - no compatible version`, `connection refused -
-  H3/WT not supported`); the raw error +
+  `>0` = loop), replacing `--once`. Each result line is aligned as
+  `URL  QUIC|H3/WT  ✓/✗  drafts-or-reason  (elapsed-ms)` — transport-appropriate
+  URL echoed (`moqt://…` / `https://…/moq-relay`), the status mark right after
+  the transport, and the elapsed time on success and failure alike. A failed
+  probe's reason is a short conclusion (e.g. `connection refused - no compatible
+  version`, `connection refused - H3/WT not supported`); the raw error +
   handshake WARNING/ERROR logs appear only under `--debug`.
 
 ## v0.10.3 (unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - **Docs:** README "Developing against a locally built aiopquic" — host-tuned
   source build vs the portable PyPI wheel, the editable-first install order for a
   separate venv per repo, and how to verify the local build is actually in use.
+- **`relay_probe`:** probes **draft-18** by default now (was 14/16 only) and
+  adds **`--draft N`** to check a single draft (e.g. `--draft 18` to watch a
+  relay's d18 rollout without the extra d14/d16 handshakes).
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
   probed **each individually, in order**; **`--offer`** instead offers the whole
   list in one session and reports the draft the relay negotiates. Looping is now
   controlled solely by **`--interval`** (`0` = probe once and exit [default],
-  `>0` = loop) — the old `--once` is removed (legacy `PROBE_ONCE` env still maps
-  to interval 0). Each result line echoes the full transport-appropriate URL
+  `>0` = loop), replacing `--once`. Each result line echoes the full
+  transport-appropriate URL
   (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport).
 
 ## v0.10.3 (unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@
 - **Docs:** README "Developing against a locally built aiopquic" — host-tuned
   source build vs the portable PyPI wheel, the editable-first install order for a
   separate venv per repo, and how to verify the local build is actually in use.
-- **`relay_probe`:** probes **draft-18** by default now (was 14/16 only) and
-  adds **`--draft`** — either a single draft (`--draft 18`, to watch a relay's
-  d18 rollout without the extra d14/d16 handshakes) or an ordered offer set in
-  one session (`--draft 18,16`, order preserved) to see which draft the relay
-  negotiates from a given preference list.
+- **`relay_probe` reworked.** Probes **draft-18** by default (was 14/16 only).
+  **`--draft`** takes a single draft (`--draft 18`) or a list (`--draft 18,16`)
+  probed **each individually, in order**; **`--offer`** instead offers the whole
+  list in one session and reports the draft the relay negotiates. Looping is now
+  controlled solely by **`--interval`** (`0` = probe once and exit [default],
+  `>0` = loop) — the old `--once` is removed (legacy `PROBE_ONCE` env still maps
+  to interval 0). Each result line echoes the full transport-appropriate URL
+  (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport).
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
   controlled solely by **`--interval`** (`0` = probe once and exit [default],
   `>0` = loop), replacing `--once`. Each result line echoes the full
   transport-appropriate URL
-  (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport).
+  (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
+  probe is reported on that one line with its error code; the underlying
+  handshake WARNING/ERROR logs appear only under `--debug`.
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.10.4 (unreleased)
+
+- **Cross-draft (d14/d16/d18) microbenchmarks.** New `b8_control_roundtrip`
+  times encode+decode of SUBSCRIBE / SUBSCRIBE_OK / PUBLISH / PUBLISH_OK /
+  REQUEST_UPDATE at all three drafts (each round-trip verified before timing),
+  and `b7_framer --draft all` / `b1_parser --draft all` add cross-draft
+  TX-framing and RX-parse comparisons. Each prints a relative-to-d16 summary.
+  Measured: d16→d18 is parity (within ~2%) across control, framing, and parse —
+  the cost step is d14→d16 (the KVP redesign). Also fixes a latent bug in
+  `b7_framer` where `--draft` was ignored (the probes always built an RFC9000
+  header); it now threads the per-draft profile so each draft encodes its own
+  wire form.
+- **Docs:** README "Developing against a locally built aiopquic" — host-tuned
+  source build vs the portable PyPI wheel, the editable-first install order for a
+  separate venv per repo, and how to verify the local build is actually in use.
+
 ## v0.10.3 (unreleased)
 
 - **draft-18 pub-sub object delivery fixed (REQUEST_UPDATE wire format).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   transport-appropriate URL
   (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
   probe is reported on that one line as a short `status - reason` conclusion
-  (e.g. `handshake refused - no compatible draft/version`); the raw error +
+  (e.g. `connection refused - no compatible draft/version`); the raw error +
   handshake WARNING/ERROR logs appear only under `--debug`.
 
 ## v0.10.3 (unreleased)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@
   source build vs the portable PyPI wheel, the editable-first install order for a
   separate venv per repo, and how to verify the local build is actually in use.
 - **`relay_probe`:** probes **draft-18** by default now (was 14/16 only) and
-  adds **`--draft N`** to check a single draft (e.g. `--draft 18` to watch a
-  relay's d18 rollout without the extra d14/d16 handshakes).
+  adds **`--draft`** — either a single draft (`--draft 18`, to watch a relay's
+  d18 rollout without the extra d14/d16 handshakes) or an ordered offer set in
+  one session (`--draft 18,16`, order preserved) to see which draft the relay
+  negotiates from a given preference list.
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@
   `>0` = loop), replacing `--once`. Each result line echoes the full
   transport-appropriate URL
   (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
-  probe is reported on that one line as a short conclusion (e.g. "no compatible
-  draft (no shared ALPN/version)"); the raw error + handshake WARNING/ERROR logs
-  appear only under `--debug`.
+  probe is reported on that one line as a short `status - reason` conclusion
+  (e.g. `handshake refused - no compatible draft/version`); the raw error +
+  handshake WARNING/ERROR logs appear only under `--debug`.
 
 ## v0.10.3 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
   transport-appropriate URL
   (`moqt://…` for raw QUIC, `https://…/moq-relay` for H3/WebTransport). A failed
   probe is reported on that one line as a short `status - reason` conclusion
-  (e.g. `connection refused - no compatible draft/version`); the raw error +
+  (e.g. `connection refused - no compatible version`, `connection refused -
+  H3/WT not supported`); the raw error +
   handshake WARNING/ERROR logs appear only under `--debug`.
 
 ## v0.10.3 (unreleased)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,48 @@ mkdir -p certs && openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
 pytest aiomoqt/tests/
 ```
 
+### Developing against a locally built aiopquic
+
+The PyPI `aiopquic` wheel is built **portable** (runs on any CPU of the
+architecture). A locally compiled `aiopquic` is **host-tuned** (`-O3
+-march=native -flto`, plus picotls Fusion AES-GCM on x86_64) and is
+measurably faster in many cases — build it from source when benchmarking or
+optimizing, and on bare-metal targets generally.
+
+```bash
+# build aiopquic from source (host-tuned by default)
+git clone https://github.com/gmarzot/aiopquic.git
+cd aiopquic
+git submodule update --init --recursive
+./build_picoquic.sh          # -march/-mcpu=native -flto; AIOPQUIC_WHEEL_BUILD=1 for a portable build
+```
+
+`aiomoqt`'s venv must then have **this editable aiopquic** installed —
+otherwise `uv pip install -e` pulls the portable wheel from PyPI. In a single
+shared venv, install both editable. With a **separate venv per repo** (e.g. two
+shells), install the local aiopquic into the aiomoqt venv **first**, so the
+dependency is already satisfied and no wheel is fetched:
+
+```bash
+# in the aiomoqt venv:
+uv pip install -e ~/aiopquic     # local source, editable — BEFORE aiomoqt
+uv pip install -e '.[test]'      # aiopquic dep already satisfied → no wheel
+```
+
+If aiomoqt already grabbed the wheel, just re-run `uv pip install -e ~/aiopquic`
+— it replaces the wheel install. Confirm the local build is actually in use
+(this catches the wheel sneaking back in):
+
+```bash
+python -c "import aiopquic; print(aiopquic.__file__)"   # must be <repo>/src/aiopquic/…, not …/site-packages/
+python -m aiomoqt.versions                              # aiopquic path + picoquic/picotls SHAs match your build
+```
+
+Both venvs must use the **same Python version** — the editable build's compiled
+extension lives in the aiopquic source tree and is shared across venvs that
+point at it. C/Cython changes need a rebuild (`./build_picoquic.sh` if the C
+libs changed, then `uv pip install -e ~/aiopquic`); pure-Python edits are live.
+
 ## Known Limitations
 
 - **draft-18 is beta.** Negotiated by default (`(18, 16, 14)`, newest-first) over raw QUIC and WebTransport, with control + SUBGROUP object delivery validated end to end. Not yet complete: SUBSCRIBE / PUBLISH subscription-filter and largest-location still use the d16 nested form; d18 FETCH is pending; Track-Properties extensions encode as RFC9000 varints (correct for the small values in use). draft-14 / draft-16 are unaffected and remain the stable path.

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -330,6 +330,26 @@ def _parse_args():
     return p.parse_args()
 
 
+def _classify_error(err: str) -> str:
+    """Map a raw probe error to a short human conclusion for the quiet
+    one-line output. The raw error is shown under --debug."""
+    e = (err or "").lower()
+    if "error_code=376" in e:  # CRYPTO_ERROR + TLS no_application_protocol
+        return "no compatible draft (no shared ALPN/version)"
+    if "timeout" in e:
+        return "no response (handshake timeout)"
+    if "wt connect refused" in e:
+        return "WebTransport CONNECT refused (wrong path, or not a WT relay)"
+    if ("name or service not known" in e or "gaierror" in e
+            or "getaddr" in e):
+        return "DNS lookup failed (host not found)"
+    if "refused" in e:
+        return "connection refused"
+    if "during handshake" in e:
+        return "handshake failed"
+    return err or "unreachable"
+
+
 async def _probe_single_url(url, timeout, debug=False):
     """One-shot probe: print one human-readable line per (draft, transport)
     combo. No JSON, no file I/O. Exits with code 0 if any draft was LIVE,
@@ -356,7 +376,9 @@ async def _probe_single_url(url, timeout, debug=False):
               f"  {drafts}  ✓ ({result['latency_ms']}ms)")
         return 0
     err = result.get("error") or "unreachable"
-    print(f"{url}  {transport.lower():<8}  ✗ {err}")
+    conclusion = _classify_error(err)
+    suffix = f"  ({err})" if (debug and conclusion != err) else ""
+    print(f"{url}  {transport.lower():<8}  ✗ {conclusion}{suffix}")
     return 1
 
 

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from aiomoqt.client import MOQTClient
 from aiomoqt.types import (
-    MOQT_VERSION_DRAFT14, MOQT_VERSION_DRAFT16, MOQTRequestError,
+    MOQTRequestError,
     moqt_version_from_draft,
     parse_draft_spec,
 )
@@ -40,11 +40,9 @@ logger = logging.getLogger("relay-probe")
 # rebinds these from argparse defaults when the module is invoked
 # directly, giving CLI-over-env precedence.
 PROBE_TIMEOUT = int(os.getenv("PROBE_TIMEOUT", "8"))
-# Looping is expressed solely by PROBE_INTERVAL: 0 (default) = probe once and
-# exit; >0 = loop every N seconds. The legacy PROBE_ONCE env is still honored
-# (truthy -> run once) for back-compat with existing deployments.
-_LEGACY_ONCE = os.getenv("PROBE_ONCE", "").lower() in ("1", "true", "yes")
-PROBE_INTERVAL = 0 if _LEGACY_ONCE else int(os.getenv("PROBE_INTERVAL", "0"))
+# PROBE_INTERVAL controls looping: 0 = probe once and exit, >0 = loop every
+# N seconds.
+PROBE_INTERVAL = int(os.getenv("PROBE_INTERVAL", "0"))
 RELAYS_FILE = os.getenv("RELAYS_FILE", "/app/relays.json")
 OUTPUT_FILE = os.getenv("OUTPUT_FILE", "/output/relay-status.json")
 
@@ -52,9 +50,7 @@ OUTPUT_FILE = os.getenv("OUTPUT_FILE", "/output/relay-status.json")
 # run before d16 (which sends wt-available-protocols) to avoid
 # relay state issues on sequential probes to the same endpoint.
 DRAFT_PROBES = [
-    # Draft numbers (short int) — public MoQTClient API form.
-    # MOQT_VERSION_DRAFT14/16 constants are currently the full hex
-    # wire-form pending refactor (see memory:project_int_form_refactor).
+    # Draft numbers (the public MoQTClient supported_drafts form).
     ("draft-14", 14),
     ("draft-16", 16),
     ("draft-18", 18),
@@ -284,8 +280,7 @@ def _parse_args():
         epilog=(
             "Each CLI flag defaults from its matching environment "
             "variable (RELAYS_FILE, OUTPUT_FILE, PROBE_TIMEOUT, "
-            "PROBE_INTERVAL; legacy PROBE_ONCE still maps to interval 0), "
-            "so container deployments "
+            "PROBE_INTERVAL), so container deployments "
             "that set env vars keep working unchanged. CLI flags "
             "override env. A per-relay 'interval' field in the "
             "relays file overrides --interval for that relay. "
@@ -309,8 +304,7 @@ def _parse_args():
     p.add_argument(
         "--interval", type=int, default=PROBE_INTERVAL, metavar="SEC",
         help=f"loop period: 0 = probe once and exit, >0 = loop every SEC "
-             f"(env: PROBE_INTERVAL; default: {PROBE_INTERVAL}). Replaces the "
-             f"old --once, which is now just the default (--interval 0).")
+             f"(env: PROBE_INTERVAL; default: {PROBE_INTERVAL}).")
     p.add_argument(
         "--draft", default=None, metavar="SPEC",
         help="draft(s) to probe: a single draft (--draft 18) or a list "

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -40,10 +40,13 @@ logger = logging.getLogger("relay-probe")
 # rebinds these from argparse defaults when the module is invoked
 # directly, giving CLI-over-env precedence.
 PROBE_TIMEOUT = int(os.getenv("PROBE_TIMEOUT", "8"))
-PROBE_INTERVAL = int(os.getenv("PROBE_INTERVAL", "300"))
+# Looping is expressed solely by PROBE_INTERVAL: 0 (default) = probe once and
+# exit; >0 = loop every N seconds. The legacy PROBE_ONCE env is still honored
+# (truthy -> run once) for back-compat with existing deployments.
+_LEGACY_ONCE = os.getenv("PROBE_ONCE", "").lower() in ("1", "true", "yes")
+PROBE_INTERVAL = 0 if _LEGACY_ONCE else int(os.getenv("PROBE_INTERVAL", "0"))
 RELAYS_FILE = os.getenv("RELAYS_FILE", "/app/relays.json")
 OUTPUT_FILE = os.getenv("OUTPUT_FILE", "/output/relay-status.json")
-PROBE_ONCE = os.getenv("PROBE_ONCE", "").lower() in ("1", "true", "yes")
 
 # Draft versions to probe, oldest first — d14 bare WT CONNECT must
 # run before d16 (which sends wt-available-protocols) to avoid
@@ -266,8 +269,8 @@ async def run_loop():
         tmp.rename(out)
         logger.info(f"Wrote {out}")
 
-        if PROBE_ONCE:
-            break
+        if PROBE_INTERVAL <= 0:
+            break  # interval 0 = probe once and exit
 
         logger.info(f"Next probe in {PROBE_INTERVAL}s")
         await asyncio.sleep(PROBE_INTERVAL)
@@ -281,7 +284,8 @@ def _parse_args():
         epilog=(
             "Each CLI flag defaults from its matching environment "
             "variable (RELAYS_FILE, OUTPUT_FILE, PROBE_TIMEOUT, "
-            "PROBE_INTERVAL, PROBE_ONCE), so container deployments "
+            "PROBE_INTERVAL; legacy PROBE_ONCE still maps to interval 0), "
+            "so container deployments "
             "that set env vars keep working unchanged. CLI flags "
             "override env. A per-relay 'interval' field in the "
             "relays file overrides --interval for that relay. "
@@ -304,17 +308,20 @@ def _parse_args():
              f"default: {PROBE_TIMEOUT})")
     p.add_argument(
         "--interval", type=int, default=PROBE_INTERVAL, metavar="SEC",
-        help=f"seconds between probe cycles (env: PROBE_INTERVAL; "
-             f"default: {PROBE_INTERVAL})")
-    p.add_argument(
-        "--once", action="store_true", default=PROBE_ONCE,
-        help="probe once and exit (env: PROBE_ONCE=1)")
+        help=f"loop period: 0 = probe once and exit, >0 = loop every SEC "
+             f"(env: PROBE_INTERVAL; default: {PROBE_INTERVAL}). Replaces the "
+             f"old --once, which is now just the default (--interval 0).")
     p.add_argument(
         "--draft", default=None, metavar="SPEC",
-        help="probe a single draft (e.g. --draft 18) OR an ordered offer "
-             "set in one session (e.g. --draft 18,16 to offer both, 18 "
-             "first) — passed verbatim as the session's supported_drafts, so "
-             "order is preserved. Default probes 14, 16, 18 separately.")
+        help="draft(s) to probe: a single draft (--draft 18) or a list "
+             "(--draft 18,16). By default each listed draft is probed "
+             "INDIVIDUALLY, in order; with --offer the whole list is offered "
+             "in ONE session. Default (no --draft) probes 14, 16, 18 each.")
+    p.add_argument(
+        "--offer", action="store_true", default=False,
+        help="with a multi-draft --draft, offer the whole list in ONE "
+             "session (ordered as given) and report the draft the relay "
+             "negotiates, instead of probing each draft separately.")
     p.add_argument(
         "--url", default=None, metavar="URL",
         help="probe a single relay URL (e.g. moqt://host:port or "
@@ -345,12 +352,11 @@ async def _probe_single_url(url, timeout, debug=False):
     transport = result["transport"]
     if result["live"]:
         drafts = ",".join(result["drafts"])
-        print(f"{result['host']}:{result['port']}  {transport.lower():<8}"
+        print(f"{url}  {transport.lower():<8}"
               f"  {drafts}  ✓ ({result['latency_ms']}ms)")
         return 0
     err = result.get("error") or "unreachable"
-    print(f"{result['host']}:{result['port']}  {transport.lower():<8}"
-          f"  ✗ {err}")
+    print(f"{url}  {transport.lower():<8}  ✗ {err}")
     return 1
 
 
@@ -358,11 +364,17 @@ if __name__ == "__main__":
     args = _parse_args()
     if args.draft is not None:
         try:
-            DRAFT_FILTER = [(f"draft-{args.draft}",
-                             parse_draft_spec(args.draft))]
+            spec = parse_draft_spec(args.draft)
         except ValueError as e:
             print(f"relay_probe: bad --draft value: {e}", file=sys.stderr)
             sys.exit(2)
+        if args.offer:
+            # Offer the whole set in one session (ordered); report negotiated.
+            DRAFT_FILTER = [(f"draft-{args.draft}", spec)]
+        else:
+            # Probe each listed draft individually, in the given order.
+            drafts = spec if isinstance(spec, list) else [spec]
+            DRAFT_FILTER = [(f"draft-{d}", d) for d in drafts]
     if args.url:
         # Single-URL mode: skip the relays-file / output-file machinery.
         rc = asyncio.run(_probe_single_url(
@@ -375,5 +387,4 @@ if __name__ == "__main__":
     OUTPUT_FILE = args.output_file
     PROBE_TIMEOUT = args.timeout
     PROBE_INTERVAL = args.interval
-    PROBE_ONCE = args.once
     asyncio.run(run_loop())

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -376,15 +376,14 @@ async def _probe_single_url(url, timeout, debug=False):
     PROBE_TIMEOUT = timeout
     result = await probe_endpoint(url)
     transport = result["transport"]
+    ms = result.get("latency_ms", 0)
     if result["live"]:
         drafts = ",".join(result["drafts"])
-        print(f"{url}  {transport:<8}"
-              f"  {drafts}  ✓ ({result['latency_ms']}ms)")
+        print(f"{url:<48}  {transport:<5}  ✓  {drafts}  ({ms}ms)")
         return 0
     err = result.get("error") or "unreachable"
     conclusion = _classify_error(err, transport)
-    suffix = f"  ({err})" if (debug and conclusion != err) else ""
-    print(f"{url}  {transport:<8}  ✗ {conclusion}{suffix}")
+    print(f"{url:<48}  {transport:<5}  ✗  {conclusion}  ({ms}ms)")
     return 1
 
 

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -52,7 +52,12 @@ DRAFT_PROBES = [
     # wire-form pending refactor (see memory:project_int_form_refactor).
     ("draft-14", 14),
     ("draft-16", 16),
+    ("draft-18", 18),
 ]
+
+# Set from --draft to probe a single draft instead of the full DRAFT_PROBES
+# list (None = probe all of DRAFT_PROBES).
+DRAFT_FILTER = None
 
 
 async def probe_version(host, port, path, use_quic, supported_drafts,
@@ -116,7 +121,7 @@ async def probe_endpoint(url, verify_tls=False):
     drafts = []
     results = []
 
-    for draft_name, supported_drafts in DRAFT_PROBES:
+    for draft_name, supported_drafts in (DRAFT_FILTER or DRAFT_PROBES):
         r = await probe_version(
             host, port, path, use_quic, supported_drafts, verify_tls,
         )
@@ -299,6 +304,10 @@ def _parse_args():
         "--once", action="store_true", default=PROBE_ONCE,
         help="probe once and exit (env: PROBE_ONCE=1)")
     p.add_argument(
+        "--draft", type=int, default=None, metavar="N",
+        help="probe only this draft number (e.g. --draft 18); default "
+             "probes 14, 16, and 18.")
+    p.add_argument(
         "--url", default=None, metavar="URL",
         help="probe a single relay URL (e.g. moqt://host:port or "
              "https://host:port/path) and print one line per probed "
@@ -339,6 +348,8 @@ async def _probe_single_url(url, timeout, debug=False):
 
 if __name__ == "__main__":
     args = _parse_args()
+    if args.draft is not None:
+        DRAFT_FILTER = [(f"draft-{args.draft}", args.draft)]
     if args.url:
         # Single-URL mode: skip the relays-file / output-file machinery.
         rc = asyncio.run(_probe_single_url(

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -335,11 +335,17 @@ async def _probe_single_url(url, timeout, debug=False):
     combo. No JSON, no file I/O. Exits with code 0 if any draft was LIVE,
     else 1 — easy to wire into shell scripts."""
     from aiomoqt.utils.logger import set_log_level
-    # Default quiet: suppress aiomoqt's INFO chatter so stdout is one
-    # clean line. --debug bumps everything (incl. handshake details).
-    set_log_level(logging.DEBUG if debug else logging.WARNING)
-    logging.getLogger("relay-probe").setLevel(
-        logging.DEBUG if debug else logging.WARNING)
+    # Default quiet: only the one-line result reaches stdout. Suppress the
+    # aiomoqt + aiopquic connection logs (including handshake-failure
+    # WARNING/ERROR) — a failed probe is still reported on the printed ✗ line
+    # with its error code. --debug shows the full handshake.
+    if debug:
+        set_log_level(logging.DEBUG)
+        logging.getLogger("relay-probe").setLevel(logging.DEBUG)
+    else:
+        set_log_level(logging.CRITICAL)
+        logging.getLogger("relay-probe").setLevel(logging.WARNING)
+        logging.getLogger("aiopquic").setLevel(logging.CRITICAL)
     global PROBE_TIMEOUT
     PROBE_TIMEOUT = timeout
     result = await probe_endpoint(url)

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -339,7 +339,7 @@ def _classify_error(err: str) -> str:
     if "timeout" in e:
         return "no response (handshake timeout)"
     if "wt connect refused" in e:
-        return "WebTransport CONNECT refused (wrong path, or not a WT relay)"
+        return "WebTransport CONNECT refused (draft not supported, or wrong path)"
     if ("name or service not known" in e or "gaierror" in e
             or "getaddr" in e):
         return "DNS lookup failed (host not found)"

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -60,6 +60,11 @@ DRAFT_PROBES = [
 # list (None = probe all of DRAFT_PROBES).
 DRAFT_FILTER = None
 
+# --url one-line output: left-pad the URL to this column so a host's QUIC and
+# H3/WT lines align (and consecutive single-URL probes line up). Sized to a
+# typical longest relay URL; longer URLs simply extend past it.
+_URL_COL = 48
+
 
 async def probe_version(host, port, path, use_quic, supported_drafts,
                         verify_tls=False):
@@ -379,11 +384,11 @@ async def _probe_single_url(url, timeout, debug=False):
     ms = result.get("latency_ms", 0)
     if result["live"]:
         drafts = ",".join(result["drafts"])
-        print(f"{url:<48}  {transport:<5}  ✓  {drafts}  ({ms}ms)")
+        print(f"{url:<{_URL_COL}}  {transport:<5}  ✓  {drafts}  ({ms}ms)")
         return 0
     err = result.get("error") or "unreachable"
     conclusion = _classify_error(err, transport)
-    print(f"{url:<48}  {transport:<5}  ✗  {conclusion}  ({ms}ms)")
+    print(f"{url:<{_URL_COL}}  {transport:<5}  ✗  {conclusion}  ({ms}ms)")
     return 1
 
 

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -336,24 +336,24 @@ def _classify_error(err: str, transport: str = "") -> str:
     e = (err or "").lower()
     is_wt = "wt" in transport.lower() or "h3" in transport.lower()
     if "error_code=376" in e:  # TLS no_application_protocol (ALPN mismatch)
-        # Over WT the offered ALPN is "h3"; 376 there means the relay isn't
-        # an H3/WebTransport server. Over raw QUIC it's the moqt-NN ALPN, so
-        # 376 means no shared draft.
+        # Over H3/WT the offered ALPN is "h3"; 376 means the relay isn't an
+        # H3/WT server. Over QUIC it's the moqt-NN ALPN, so 376 means no
+        # shared version.
         if is_wt:
-            return "connection refused - h3/webtransport not supported"
-        return "connection refused - no compatible draft/version"
+            return "connection refused - H3/WT not supported"
+        return "connection refused - no compatible version"
     if "wt connect refused" in e:
-        return "connection refused - draft not supported or wrong path"
+        return "connection refused - no compatible version or wrong path"
     if "timeout" in e:
-        return "no response - handshake timed out"
+        return "connection refused - no response"
     if ("name or service not known" in e or "gaierror" in e
             or "getaddr" in e or "name resolution" in e):
-        return "DNS lookup failed - host did not resolve"
+        return "connection refused - could not resolve host"
     if "refused" in e:
         return "connection refused - nothing listening"
     if "during handshake" in e:
         return "connection refused - handshake failed"
-    return err or "unreachable"
+    return f"connection refused - {err}" if err else "connection refused"
 
 
 async def _probe_single_url(url, timeout, debug=False):
@@ -378,13 +378,13 @@ async def _probe_single_url(url, timeout, debug=False):
     transport = result["transport"]
     if result["live"]:
         drafts = ",".join(result["drafts"])
-        print(f"{url}  {transport.lower():<8}"
+        print(f"{url}  {transport:<8}"
               f"  {drafts}  ✓ ({result['latency_ms']}ms)")
         return 0
     err = result.get("error") or "unreachable"
     conclusion = _classify_error(err, transport)
     suffix = f"  ({err})" if (debug and conclusion != err) else ""
-    print(f"{url}  {transport.lower():<8}  ✗ {conclusion}{suffix}")
+    print(f"{url}  {transport:<8}  ✗ {conclusion}{suffix}")
     return 1
 
 

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -330,23 +330,29 @@ def _parse_args():
     return p.parse_args()
 
 
-def _classify_error(err: str) -> str:
+def _classify_error(err: str, transport: str = "") -> str:
     """Map a raw probe error to a short 'status - reason' conclusion for the
     quiet one-line output. The raw error is shown under --debug."""
     e = (err or "").lower()
-    if "error_code=376" in e:  # CRYPTO_ERROR + TLS no_application_protocol
-        return "handshake refused - no compatible draft/version"
+    is_wt = "wt" in transport.lower() or "h3" in transport.lower()
+    if "error_code=376" in e:  # TLS no_application_protocol (ALPN mismatch)
+        # Over WT the offered ALPN is "h3"; 376 there means the relay isn't
+        # an H3/WebTransport server. Over raw QUIC it's the moqt-NN ALPN, so
+        # 376 means no shared draft.
+        if is_wt:
+            return "connection refused - h3/webtransport not supported"
+        return "connection refused - no compatible draft/version"
+    if "wt connect refused" in e:
+        return "connection refused - draft not supported or wrong path"
     if "timeout" in e:
         return "no response - handshake timed out"
-    if "wt connect refused" in e:
-        return "CONNECT refused - draft not supported or wrong path"
     if ("name or service not known" in e or "gaierror" in e
             or "getaddr" in e or "name resolution" in e):
         return "DNS lookup failed - host did not resolve"
     if "refused" in e:
         return "connection refused - nothing listening"
     if "during handshake" in e:
-        return "handshake failed - transport error"
+        return "connection refused - handshake failed"
     return err or "unreachable"
 
 
@@ -376,7 +382,7 @@ async def _probe_single_url(url, timeout, debug=False):
               f"  {drafts}  ✓ ({result['latency_ms']}ms)")
         return 0
     err = result.get("error") or "unreachable"
-    conclusion = _classify_error(err)
+    conclusion = _classify_error(err, transport)
     suffix = f"  ({err})" if (debug and conclusion != err) else ""
     print(f"{url}  {transport.lower():<8}  ✗ {conclusion}{suffix}")
     return 1

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -339,7 +339,7 @@ def _classify_error(err: str) -> str:
     if "timeout" in e:
         return "no response (handshake timeout)"
     if "wt connect refused" in e:
-        return "WebTransport CONNECT refused (draft not supported, or wrong path)"
+        return "CONNECT refused (draft not supported, or wrong path)"
     if ("name or service not known" in e or "gaierror" in e
             or "getaddr" in e):
         return "DNS lookup failed (host not found)"

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,7 @@ from aiomoqt.client import MOQTClient
 from aiomoqt.types import (
     MOQT_VERSION_DRAFT14, MOQT_VERSION_DRAFT16, MOQTRequestError,
     moqt_version_from_draft,
+    parse_draft_spec,
 )
 from aiomoqt.utils.url import parse_relay_url
 
@@ -127,8 +129,12 @@ async def probe_endpoint(url, verify_tls=False):
         )
         results.append(r)
         if r["live"]:
-            drafts.append(draft_name)
-            logger.info(f"  {url} [{transport}] {draft_name}: LIVE"
+            # For a multi-draft offer the label is the offered set; report
+            # which draft the relay actually negotiated.
+            negotiated = r["draft"] or draft_name
+            drafts.append(negotiated)
+            arrow = "" if negotiated == draft_name else f" -> {negotiated}"
+            logger.info(f"  {url} [{transport}] {draft_name}{arrow}: LIVE"
                         f" (alpn={r['alpn']})")
         else:
             logger.info(f"  {url} [{transport}] {draft_name}: {r['error']}")
@@ -304,9 +310,11 @@ def _parse_args():
         "--once", action="store_true", default=PROBE_ONCE,
         help="probe once and exit (env: PROBE_ONCE=1)")
     p.add_argument(
-        "--draft", type=int, default=None, metavar="N",
-        help="probe only this draft number (e.g. --draft 18); default "
-             "probes 14, 16, and 18.")
+        "--draft", default=None, metavar="SPEC",
+        help="probe a single draft (e.g. --draft 18) OR an ordered offer "
+             "set in one session (e.g. --draft 18,16 to offer both, 18 "
+             "first) — passed verbatim as the session's supported_drafts, so "
+             "order is preserved. Default probes 14, 16, 18 separately.")
     p.add_argument(
         "--url", default=None, metavar="URL",
         help="probe a single relay URL (e.g. moqt://host:port or "
@@ -349,7 +357,12 @@ async def _probe_single_url(url, timeout, debug=False):
 if __name__ == "__main__":
     args = _parse_args()
     if args.draft is not None:
-        DRAFT_FILTER = [(f"draft-{args.draft}", args.draft)]
+        try:
+            DRAFT_FILTER = [(f"draft-{args.draft}",
+                             parse_draft_spec(args.draft))]
+        except ValueError as e:
+            print(f"relay_probe: bad --draft value: {e}", file=sys.stderr)
+            sys.exit(2)
     if args.url:
         # Single-URL mode: skip the relays-file / output-file machinery.
         rc = asyncio.run(_probe_single_url(

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -331,22 +331,22 @@ def _parse_args():
 
 
 def _classify_error(err: str) -> str:
-    """Map a raw probe error to a short human conclusion for the quiet
-    one-line output. The raw error is shown under --debug."""
+    """Map a raw probe error to a short 'status - reason' conclusion for the
+    quiet one-line output. The raw error is shown under --debug."""
     e = (err or "").lower()
     if "error_code=376" in e:  # CRYPTO_ERROR + TLS no_application_protocol
-        return "no compatible draft (no shared ALPN/version)"
+        return "handshake refused - no compatible draft/version"
     if "timeout" in e:
-        return "no response (handshake timeout)"
+        return "no response - handshake timed out"
     if "wt connect refused" in e:
-        return "CONNECT refused (draft not supported, or wrong path)"
+        return "CONNECT refused - draft not supported or wrong path"
     if ("name or service not known" in e or "gaierror" in e
-            or "getaddr" in e):
-        return "DNS lookup failed (host not found)"
+            or "getaddr" in e or "name resolution" in e):
+        return "DNS lookup failed - host did not resolve"
     if "refused" in e:
-        return "connection refused"
+        return "connection refused - nothing listening"
     if "during handshake" in e:
-        return "handshake failed"
+        return "handshake failed - transport error"
     return err or "unreachable"
 
 

--- a/aiomoqt/tests/microbench/_bytestream.py
+++ b/aiomoqt/tests/microbench/_bytestream.py
@@ -21,17 +21,21 @@ def make_subgroup_stream(
     track_alias: int = 1,
     group_id: int = 0,
     extensions: bool = False,
+    draft: int = 16,
 ) -> bytes:
     """Build a complete subgroup stream: header + n_objects.
 
-    payload_size is the length of each object's payload. Returns the
-    concatenated bytes ready to feed to the parser.
+    payload_size is the length of each object's payload. `draft` selects
+    the wire codec (vi64 for d18, RFC9000 for d14/d16) so the corpus is
+    valid wire for that draft. Returns the concatenated bytes ready to
+    feed to the parser.
     """
     sg = SubgroupHeader(
         track_alias=track_alias,
         group_id=group_id,
         subgroup_id=0,
         extensions_present=extensions,
+        prof=profile_for(draft),
     )
     out = bytearray()
     out += bytes(sg.serialize().data)

--- a/aiomoqt/tests/microbench/_stats.py
+++ b/aiomoqt/tests/microbench/_stats.py
@@ -5,7 +5,6 @@ on `summary()`. Cheap; appends to a list, sort-once at end.
 """
 from __future__ import annotations
 
-import bisect
 import time
 
 

--- a/aiomoqt/tests/microbench/b1_parser.py
+++ b/aiomoqt/tests/microbench/b1_parser.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import time
 
+from aiomoqt.context import profile_for
 from aiomoqt.messages.base import MOQTUnderflow
 from aiomoqt.messages.track import SubgroupHeader, ObjectHeader
 from aiopquic.streamchain import StreamChain
@@ -30,25 +31,31 @@ from aiomoqt.tests.microbench._bytestream import (
 )
 
 
-def _parse_subgroup_stream(chain: StreamChain) -> int:
+def _parse_subgroup_stream(chain: StreamChain, prof=None) -> int:
     """Drive the parser over one subgroup stream's worth of bytes.
 
     Returns object count parsed. Mirrors what _moqt_handle_data_stream
-    does (without the protocol-session bookkeeping)."""
+    does (without the protocol-session bookkeeping). `prof` selects the
+    draft codec: the chain is tagged vi64 (d18) so its push/pull and the
+    fused object parser dispatch to the right integer flavor."""
+    vi64 = prof is not None and prof.vi64
+    chain.vi64 = vi64
 
-    # Stream type byte (varint) + SubgroupHeader
+    # Stream type (varint flavor per draft) + SubgroupHeader
     stream_type = chain.pull_uint_var()
-    sg = SubgroupHeader.deserialize(chain, type_val=stream_type)
+    sg = SubgroupHeader.deserialize(chain, type_val=stream_type, prof=prof)
 
     n_objects = 0
     cap = chain.capacity
+    obj = ObjectHeader.__new__(ObjectHeader)
     while chain.tell() < cap:
         chain.save()
         try:
-            obj = ObjectHeader.deserialize(
+            obj.deserialize_into(
                 chain, cap,
                 extensions_present=sg.extensions_present,
                 prev_object_id=sg._last_object_id,
+                vi64=vi64,
             )
         except MOQTUnderflow:
             chain.rollback()
@@ -60,6 +67,75 @@ def _parse_subgroup_stream(chain: StreamChain) -> int:
     return n_objects
 
 
+_COMPARE_DRAFTS = (14, 16, 18)
+
+
+def _run_draft(draft, n_objects, payload_size, chunk_size,
+               duration, warmup) -> dict:
+    """Build the draft's corpus and time the RX parse loop over it.
+    Returns a result dict (obj/s, ns/obj, Mbps, corpus size)."""
+    prof = profile_for(draft)
+    data = make_subgroup_stream(n_objects, payload_size, draft=draft)
+    chunks = chunked(data, chunk_size) if chunk_size else [data]
+
+    end = time.perf_counter() + warmup
+    while time.perf_counter() < end:
+        chain = StreamChain()
+        for c in chunks:
+            chain.extend(c)
+        _parse_subgroup_stream(chain, prof=prof)
+
+    t0 = time.perf_counter()
+    end = t0 + duration
+    streams = objects = bytes_done = 0
+    while time.perf_counter() < end:
+        chain = StreamChain()
+        for c in chunks:
+            chain.extend(c)
+        objects += _parse_subgroup_stream(chain, prof=prof)
+        streams += 1
+        bytes_done += len(data)
+    elapsed = time.perf_counter() - t0
+    return {
+        "draft": draft,
+        "corpus": len(data),
+        "obj_s": objects / elapsed if elapsed else 0.0,
+        "ns_per_obj": (elapsed * 1e9) / objects if objects else 0.0,
+        "mbps": (bytes_done * 8) / (elapsed * 1e6) if elapsed else 0.0,
+    }
+
+
+def run_compare(n_objects, payload_size, chunk_size, duration, warmup) -> int:
+    """Cross-draft RX-parse comparison: parse each draft's valid corpus and
+    print an obj/s + ns/obj table with a relative-vs-d16 column + SUMMARY."""
+    print(f"B1 — cross-draft RX parse comparison   "
+          f"{n_objects} objs × {payload_size}B  duration={duration}s")
+    print()
+    res = {d: _run_draft(d, n_objects, payload_size, chunk_size,
+                         duration, warmup) for d in _COMPARE_DRAFTS}
+
+    hdr = (f"  {'draft':<8}{'obj/s':>16}{'ns/obj':>12}"
+           f"{'Mbps':>12}{'ns vs d16':>12}")
+    print(hdr)
+    print("  " + "─" * (len(hdr) - 2))
+    base = res[16]["ns_per_obj"]
+    for d in _COMPARE_DRAFTS:
+        r = res[d]
+        rel = r["ns_per_obj"] / base if base else 0.0
+        print(f"  d{d:<7}{r['obj_s']:>16,.0f}{r['ns_per_obj']:>12,.0f}"
+              f"{r['mbps']:>12,.0f}{rel:>11.2f}x")
+
+    r18 = res[18]["ns_per_obj"] / base if base else 0.0
+    r14 = res[14]["ns_per_obj"] / base if base else 0.0
+    print()
+    print("SUMMARY  (parse ns/obj relative to d16)")
+    print(f"  RX parse   d18/d16 {r18:5.2f}x   d14/d16 {r14:5.2f}x")
+    print(f"  -> d18 vi64 subgroup parse is within {abs(r18 - 1.0) * 100:.0f}% "
+          f"of d16's RFC9000 path; the fused per-object parser keeps the "
+          f"codec fork off the hot loop.")
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description="MoQT parser throughput")
     ap.add_argument('--n-objects', type=int, default=1000)
@@ -67,11 +143,20 @@ def main():
     ap.add_argument('--chunk-size', type=int, default=1500)
     ap.add_argument('--duration', type=float, default=5.0)
     ap.add_argument('--warmup', type=float, default=0.5)
+    ap.add_argument('--draft', default='16',
+                    help="draft number, or 'all' for the cross-draft "
+                         "RX-parse comparison")
     args = ap.parse_args()
 
-    data = make_subgroup_stream(args.n_objects, args.payload_size)
+    if str(args.draft).lower() == 'all':
+        return run_compare(args.n_objects, args.payload_size,
+                           args.chunk_size, args.duration, args.warmup)
+
+    draft = int(args.draft)
+    prof = profile_for(draft)
+    data = make_subgroup_stream(args.n_objects, args.payload_size, draft=draft)
     chunks = chunked(data, args.chunk_size) if args.chunk_size else [data]
-    print(f"corpus: {len(data):,} bytes, {len(chunks)} chunks of "
+    print(f"corpus (d{draft}): {len(data):,} bytes, {len(chunks)} chunks of "
           f"~{args.chunk_size}B ({args.n_objects} objs × "
           f"{args.payload_size}B payload)")
 
@@ -81,7 +166,7 @@ def main():
         chain = StreamChain()
         for c in chunks:
             chain.extend(c)
-        _parse_subgroup_stream(chain)
+        _parse_subgroup_stream(chain, prof=prof)
 
     # Measure
     t0 = time.perf_counter()
@@ -93,7 +178,7 @@ def main():
         chain = StreamChain()
         for c in chunks:
             chain.extend(c)
-        objects += _parse_subgroup_stream(chain)
+        objects += _parse_subgroup_stream(chain, prof=prof)
         streams += 1
         bytes_done += len(data)
 

--- a/aiomoqt/tests/microbench/b4_single_session.py
+++ b/aiomoqt/tests/microbench/b4_single_session.py
@@ -41,7 +41,7 @@ async def _run(args):
     from aiomoqt.client import MOQTClient
     from aiomoqt.server import MOQTServer
     from aiomoqt.track import PublishedTrack, SubscribedTrack
-    from aiomoqt.types import MOQTMessageType, MOQT_VERSION_DRAFT16
+    from aiomoqt.types import MOQTMessageType
     from aiomoqt.utils import wait_cond_timeout
 
     cert = _find_cert()

--- a/aiomoqt/tests/microbench/b5_multi_session.py
+++ b/aiomoqt/tests/microbench/b5_multi_session.py
@@ -39,7 +39,7 @@ async def _run_for_n(n_sessions, args):
     from aiomoqt.client import MOQTClient
     from aiomoqt.server import MOQTServer
     from aiomoqt.track import PublishedTrack, SubscribedTrack
-    from aiomoqt.types import MOQTMessageType, MOQT_VERSION_DRAFT16
+    from aiomoqt.types import MOQTMessageType
     from aiomoqt.utils import wait_cond_timeout
 
     cert = _find_cert()

--- a/aiomoqt/tests/microbench/b7_framer.py
+++ b/aiomoqt/tests/microbench/b7_framer.py
@@ -25,6 +25,7 @@ import sys
 import time
 from typing import Callable
 
+from aiomoqt.context import profile_for
 from aiomoqt.messages.track import (
     ObjectHeader, SubgroupHeader, SUBGROUP_ID_EXPLICIT,
 )
@@ -100,15 +101,16 @@ def bench_object_serialize(size: int, ext: bool) -> Callable[[], None]:
     return _fn
 
 
-def bench_next_object(size: int, ext: bool) -> Callable[[], None]:
+def bench_next_object(size: int, ext: bool, prof=None) -> Callable[[], None]:
     """B7.next-object: full SubgroupHeader.next_object() per object —
     same call the publisher's _generate_subgroup makes today.
-    Includes ObjectHeader.__init__ + .serialize() + extensions encode."""
+    Includes ObjectHeader.__init__ + .serialize() + extensions encode.
+    `prof` selects the draft wire codec (vi64 for d18, RFC9000 else)."""
     payload = make_payload(size)
     sg = SubgroupHeader(
         track_alias=1, group_id=0, subgroup_id=0,
         publisher_priority=128, extensions_present=ext,
-        subgroup_id_mode=SUBGROUP_ID_EXPLICIT,
+        subgroup_id_mode=SUBGROUP_ID_EXPLICIT, prof=prof,
     )
     obj_id = 0
 
@@ -122,7 +124,7 @@ def bench_next_object(size: int, ext: bool) -> Callable[[], None]:
     return _fn
 
 
-def bench_full_emit(size: int, ext: bool) -> Callable[[], None]:
+def bench_full_emit(size: int, ext: bool, prof=None) -> Callable[[], None]:
     """B7.full-emit: the complete per-object publisher hot path
     (modulo network) — payload build + ext dict + next_object +
     immediately discard the resulting Buffer (analog of writing it
@@ -131,7 +133,7 @@ def bench_full_emit(size: int, ext: bool) -> Callable[[], None]:
     sg = SubgroupHeader(
         track_alias=1, group_id=0, subgroup_id=0,
         publisher_priority=128, extensions_present=ext,
-        subgroup_id_mode=SUBGROUP_ID_EXPLICIT,
+        subgroup_id_mode=SUBGROUP_ID_EXPLICIT, prof=prof,
     )
     obj_id = 0
     pending: list[bytes] = []
@@ -151,7 +153,8 @@ def bench_full_emit(size: int, ext: bool) -> Callable[[], None]:
     return _fn
 
 
-def bench_batched_emit(size: int, ext: bool, batch: int) -> Callable[[], None]:
+def bench_batched_emit(size: int, ext: bool, batch: int,
+                       prof=None) -> Callable[[], None]:
     """B7.batched-emit: pack `batch` objects into one Buffer + one
     'send' (stand-in: bytes() of the underlying buffer). Models
     pattern (A) from the publisher discussion — amortizes per-call
@@ -163,7 +166,7 @@ def bench_batched_emit(size: int, ext: bool, batch: int) -> Callable[[], None]:
     sg = SubgroupHeader(
         track_alias=1, group_id=0, subgroup_id=0,
         publisher_priority=128, extensions_present=ext,
-        subgroup_id_mode=SUBGROUP_ID_EXPLICIT,
+        subgroup_id_mode=SUBGROUP_ID_EXPLICIT, prof=prof,
     )
     obj_id = 0
 
@@ -184,7 +187,7 @@ def bench_batched_emit(size: int, ext: bool, batch: int) -> Callable[[], None]:
     return _fn
 
 
-def bench_subgroup_header(ext: bool) -> Callable[[], None]:
+def bench_subgroup_header(ext: bool, prof=None) -> Callable[[], None]:
     """B7.subgroup-header: SubgroupHeader.serialize() — one per new
     subgroup stream open. Measured separately because the controller
     can amortize this over many objects."""
@@ -192,7 +195,7 @@ def bench_subgroup_header(ext: bool) -> Callable[[], None]:
         sg = SubgroupHeader(
             track_alias=1, group_id=42, subgroup_id=0,
             publisher_priority=128, extensions_present=ext,
-            subgroup_id_mode=SUBGROUP_ID_EXPLICIT,
+            subgroup_id_mode=SUBGROUP_ID_EXPLICIT, prof=prof,
         )
         sg.serialize()
     return _fn
@@ -314,6 +317,74 @@ def fmt_row(r: dict) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# Cross-draft TX-framing comparison (--draft all / --compare)
+# ---------------------------------------------------------------------------
+
+_COMPARE_DRAFTS = (14, 16, 18)
+
+
+def run_compare(sz: int, ext: bool, duration: float, warmup: float,
+                batch: int) -> int:
+    """Run the key TX-framing rows for d14/d16/d18, threading each draft's
+    DraftProfile so the header/object integers genuinely encode that draft's
+    wire form (RFC9000 for d14/d16, vi64 for d18). Prints a cross-draft
+    ns/obj table with a relative-vs-d16 column and a SUMMARY verdict."""
+
+    # (row label, factory(prof) -> fn, batch_per_iter)
+    rows = [
+        ("subgroup-header",
+         lambda prof: bench_subgroup_header(ext, prof=prof), 1),
+        ("next-object",
+         lambda prof: bench_next_object(sz, ext, prof=prof), 1),
+        ("full-emit",
+         lambda prof: bench_full_emit(sz, ext, prof=prof), 1),
+        (f"batched-emit (N={batch})",
+         lambda prof: bench_batched_emit(sz, ext, batch, prof=prof), batch),
+    ]
+
+    print(f"B7 — cross-draft TX framer comparison   "
+          f"obj_size={sz}B  ext={ext}  duration={duration}s")
+    print()
+
+    # ns/obj per (row, draft)
+    table: dict = {}
+    for label, factory, b in rows:
+        table[label] = {}
+        for d in _COMPARE_DRAFTS:
+            r = run_one(label, factory(profile_for(d)),
+                        duration, warmup, sz, batch=b)
+            table[label][d] = r["ns_per_obj"]
+
+    hdr = (f"  {'row':<24}"
+           + "".join(f"{('d' + str(d) + ' ns/obj'):>14}" for d in _COMPARE_DRAFTS)
+           + f"{'d18/d16':>10}{'d14/d16':>10}")
+    print(hdr)
+    print("  " + "─" * (len(hdr) - 2))
+    for label, _f, _b in rows:
+        v14, v16, v18 = (table[label][d] for d in (14, 16, 18))
+        r18 = v18 / v16 if v16 else 0.0
+        r14 = v14 / v16 if v16 else 0.0
+        print(f"  {label:<24}"
+              f"{v14:>14,.0f}{v16:>14,.0f}{v18:>14,.0f}"
+              f"{r18:>9.2f}x{r14:>9.2f}x")
+
+    # SUMMARY — mean of per-row ratios vs d16.
+    r18s = [table[lbl][18] / table[lbl][16] for lbl, *_ in rows if table[lbl][16]]
+    r14s = [table[lbl][14] / table[lbl][16] for lbl, *_ in rows if table[lbl][16]]
+    m18 = sum(r18s) / len(r18s) if r18s else 0.0
+    m14 = sum(r14s) / len(r14s) if r14s else 0.0
+    print()
+    print("SUMMARY  (relative to d16, mean of per-row ratios)")
+    print(f"  TX framing   d18/d16 {m18:5.2f}x   d14/d16 {m14:5.2f}x")
+    print(f"  -> d18 vi64 header/object framing is within "
+          f"{abs(m18 - 1.0) * 100:.0f}% of d16's RFC9000 path; "
+          f"d14 (no DEFAULT_PRIORITY/ext bits divergence) "
+          f"{('cheaper' if m14 < 1 else 'costlier')} by "
+          f"{abs(m14 - 1.0) * 100:.0f}%.")
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--object-size", type=int, default=8192)
@@ -322,11 +393,19 @@ def main() -> int:
     p.add_argument("--extensions", type=int, choices=(0, 1), default=1)
     p.add_argument("--batch", type=int, default=16)
     p.add_argument("--csv", default=None)
-    p.add_argument("--draft", type=int, default=16)
+    p.add_argument("--draft", default="16",
+                   help="draft number, or 'all' for the cross-draft "
+                        "TX-framing comparison")
+    p.add_argument("--compare", action="store_true",
+                   help="run the cross-draft TX-framing comparison "
+                        "(same as --draft all)")
     args = p.parse_args()
 
     ext = bool(args.extensions)
     sz = args.object_size
+
+    if args.compare or str(args.draft).lower() == "all":
+        return run_compare(sz, ext, args.duration, args.warmup, args.batch)
 
     print(f"B7 — MoQT TX framer microbench   "
           f"obj_size={sz}B  ext={ext}  duration={args.duration}s")

--- a/aiomoqt/tests/microbench/b8_control_roundtrip.py
+++ b/aiomoqt/tests/microbench/b8_control_roundtrip.py
@@ -25,10 +25,6 @@ import logging
 import sys
 from typing import Callable, Optional
 
-# The control serializers log per-param at INFO; silence them so the tight
-# round-trip loop doesn't drown the table in log lines.
-logging.disable(logging.WARNING)
-
 from aiomoqt.context import profile_for
 from aiomoqt.messages import (
     Subscribe, SubscribeOk, Publish, PublishOk, RequestUpdate,
@@ -40,6 +36,10 @@ from aiomoqt.types import (
 from aiomoqt.utils.buffer import Buffer
 
 from ._stats import time_loop
+
+# The control serializers log per-param at INFO; silence them so the tight
+# round-trip loop doesn't drown the table in log lines.
+logging.disable(logging.WARNING)
 
 
 DRAFTS = (14, 16, 18)

--- a/aiomoqt/tests/microbench/b8_control_roundtrip.py
+++ b/aiomoqt/tests/microbench/b8_control_roundtrip.py
@@ -1,0 +1,294 @@
+"""B8 — MoQT CONTROL message round-trip microbench (d14/d16/d18).
+
+Isolates the per-draft control-plane layout/codec cost: length-prefixed
+vs delta-coded KVP params, uint8 vs varint param values, reply Request-ID
+gating, and RFC9000 vs vi64 message bodies. No transport, no session —
+just serialize() + deserialize() on representative control messages.
+
+For each (message, draft) the bench:
+  1. builds the message with realistic fields,
+  2. serializes once and VERIFIES it deserializes back (key fields match)
+     before timing — any combo that legitimately doesn't apply is skipped
+     and annotated,
+  3. times encode and decode separately with time_loop.
+
+Output: an ENCODE table and a DECODE table (one row per message, one
+column per draft, ns/op), then a SUMMARY with relative ratios (d18/d16,
+d14/d16) and a one-line verdict computed from the measured numbers.
+
+Run: python -m aiomoqt.tests.microbench.b8_control_roundtrip
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Callable, Optional
+
+# The control serializers log per-param at INFO; silence them so the tight
+# round-trip loop doesn't drown the table in log lines.
+logging.disable(logging.WARNING)
+
+from aiomoqt.context import profile_for
+from aiomoqt.messages import (
+    Subscribe, SubscribeOk, Publish, PublishOk, RequestUpdate,
+)
+from aiomoqt.types import (
+    MOQTMessageType, D16MessageType, GroupOrder, FilterType,
+    ForwardingPreference, ContentExistsCode, ParamType,
+)
+from aiomoqt.utils.buffer import Buffer
+
+from ._stats import time_loop
+
+
+DRAFTS = (14, 16, 18)
+
+
+# ---------------------------------------------------------------------------
+# Message construction — realistic fields per message.
+# ---------------------------------------------------------------------------
+
+def _make_subscribe() -> Subscribe:
+    return Subscribe(
+        request_id=7,
+        track_namespace=(b'live', b'sports'),
+        track_name=b'football',
+        priority=128,
+        group_order=GroupOrder.ASCENDING,
+        forward=1,
+        filter_type=FilterType.ABSOLUTE_RANGE,
+        start_group=10, start_object=5, end_group=100,
+        parameters={ParamType.DELIVERY_TIMEOUT: 5000},
+    )
+
+
+def _make_subscribe_ok() -> SubscribeOk:
+    return SubscribeOk(
+        request_id=7,
+        track_alias=42,
+        expires=300,
+        group_order=GroupOrder.ASCENDING,
+        content_exists=ContentExistsCode.EXISTS,
+        largest_group_id=50,
+        largest_object_id=200,
+        parameters={ParamType.DELIVERY_TIMEOUT: 5000},
+    )
+
+
+def _make_publish() -> Publish:
+    return Publish(
+        request_id=7,
+        track_namespace=(b'live', b'sports'),
+        track_name=b'football',
+        track_alias=42,
+        group_order=GroupOrder.ASCENDING,
+        content_exists=ContentExistsCode.EXISTS,
+        largest_group_id=50,
+        largest_object_id=200,
+        forward=ForwardingPreference.SUBGROUP,
+        parameters={ParamType.DELIVERY_TIMEOUT: 5000},
+    )
+
+
+def _make_publish_ok() -> PublishOk:
+    return PublishOk(
+        request_id=7,
+        forward=ForwardingPreference.SUBGROUP,
+        priority=128,
+        group_order=GroupOrder.ASCENDING,
+        filter_type=FilterType.ABSOLUTE_RANGE,
+        start_group=10, start_object=5, end_group=100,
+        parameters={},
+    )
+
+
+def _make_request_update() -> RequestUpdate:
+    # FORWARD (0x10) is a uint8-valued param at d18 — exercises the uint8
+    # param-value codec path there, the varint one at d14/d16.
+    return RequestUpdate(
+        request_id=7,
+        existing_request_id=5,
+        parameters={ParamType.FORWARD: 1},
+    )
+
+
+# (label, factory, type_id, is_reply)
+#   is_reply -> d18 drops the in-band Request ID on the wire (demuxed from
+#   the request stream), so request_id is absent there and excluded from the
+#   field-match verification for d18 only.
+MESSAGES = [
+    ("Subscribe",     _make_subscribe,      MOQTMessageType.SUBSCRIBE,    False),
+    ("SubscribeOk",   _make_subscribe_ok,   MOQTMessageType.SUBSCRIBE_OK, True),
+    ("Publish",       _make_publish,        MOQTMessageType.PUBLISH,      False),
+    ("PublishOk",     _make_publish_ok,     MOQTMessageType.PUBLISH_OK,   True),
+    ("RequestUpdate", _make_request_update, D16MessageType.REQUEST_UPDATE, False),
+]
+
+# Fields verified for the round-trip (kept small + load-bearing per message).
+VERIFY_FIELDS = {
+    "Subscribe":     ("request_id", "track_namespace", "track_name", "filter_type"),
+    "SubscribeOk":   ("track_alias", "expires", "largest_group_id"),
+    "Publish":       ("request_id", "track_namespace", "track_alias"),
+    "PublishOk":     ("forward", "priority", "filter_type"),
+    "RequestUpdate": ("request_id", "parameters"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip primitives.
+# ---------------------------------------------------------------------------
+
+def _strip_header(raw: bytes, draft: int) -> bytes:
+    """Strip the message Type (vi64 for d18, RFC9000 otherwise) + 16-bit
+    Length prefix, returning the message body the deserializer consumes."""
+    prof = profile_for(draft)
+    head = Buffer(data=raw)
+    head.vi64 = prof.vi64
+    head.pull_vint()            # Type
+    head.pull_uint16()          # Length
+    return raw[head.tell():]
+
+
+def _decode_body(cls, body: bytes, draft: int):
+    prof = profile_for(draft)
+    rbuf = Buffer(data=body, vi64=prof.vi64)
+    return cls.deserialize(rbuf, prof=prof, buf_end=len(body))
+
+
+def _verify(label: str, factory, is_reply: bool, draft: int) -> Optional[str]:
+    """Build + serialize + deserialize once; assert key fields survive the
+    round-trip. Returns None on success, or a skip/error reason string."""
+    cls = type(factory())
+    prof = profile_for(draft)
+    msg = factory()
+    raw = bytes(msg.serialize(prof=prof).data)
+    body = _strip_header(raw, draft)
+    out = _decode_body(cls, body, draft)
+    for fname in VERIFY_FIELDS[label]:
+        # Replies omit Request ID on the d18 wire — not a wire field there.
+        if fname == "request_id" and is_reply and draft == 18:
+            assert getattr(out, "request_id") is None, \
+                f"{label} d18 reply should omit request_id on the wire"
+            continue
+        exp = getattr(msg, fname)
+        got = getattr(out, fname)
+        assert exp == got, f"{label} d{draft}: {fname} {exp!r} != {got!r}"
+    return None
+
+
+def _enc_fn(factory, prof) -> Callable[[], None]:
+    msg = factory()
+
+    def _fn():
+        msg.serialize(prof=prof)
+    return _fn
+
+
+def _dec_fn(factory, draft) -> Callable[[], None]:
+    cls = type(factory())
+    prof = profile_for(draft)
+    raw = bytes(factory().serialize(prof=prof).data)
+    body = _strip_header(raw, draft)
+
+    def _fn():
+        rbuf = Buffer(data=body, vi64=prof.vi64)
+        cls.deserialize(rbuf, prof=prof, buf_end=len(body))
+    return _fn
+
+
+def _time_ns(fn, duration, warmup) -> float:
+    iters, elapsed = time_loop(fn, target_seconds=duration,
+                               warmup_seconds=warmup)
+    return (elapsed * 1e9) / iters if iters > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Table + summary.
+# ---------------------------------------------------------------------------
+
+def _print_table(title: str, rows: dict) -> None:
+    print(title)
+    hdr = (f"  {'message':<16}"
+           + "".join(f"{('d' + str(d) + ' ns/op'):>14}" for d in DRAFTS))
+    print(hdr)
+    print("  " + "─" * (len(hdr) - 2))
+    for label, _f, _t, _r in MESSAGES:
+        cells = []
+        for d in DRAFTS:
+            v = rows[label].get(d)
+            cells.append("skip".rjust(14) if v is None
+                         else f"{v:>14,.0f}")
+        print(f"  {label:<16}" + "".join(cells))
+    print()
+
+
+def _ratios(rows: dict) -> tuple[float, float]:
+    """Mean d18/d16 and d14/d16 across messages with all three present."""
+    r18, r14 = [], []
+    for label, *_ in MESSAGES:
+        v14, v16, v18 = (rows[label].get(d) for d in (14, 16, 18))
+        if v16:
+            if v18:
+                r18.append(v18 / v16)
+            if v14:
+                r14.append(v14 / v16)
+    def mean(xs):
+        return sum(xs) / len(xs) if xs else 0.0
+    return mean(r18), mean(r14)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="MoQT control-message round-trip microbench (d14/d16/d18)")
+    p.add_argument("--duration", type=float, default=2.0)
+    p.add_argument("--warmup", type=float, default=0.3)
+    args = p.parse_args()
+
+    print(f"B8 — MoQT control round-trip   drafts={DRAFTS}  "
+          f"duration={args.duration}s")
+    print()
+
+    enc: dict = {n: {} for n, *_ in MESSAGES}
+    dec: dict = {n: {} for n, *_ in MESSAGES}
+    skips: list[str] = []
+
+    for label, factory, _type_id, is_reply in MESSAGES:
+        for d in DRAFTS:
+            prof = profile_for(d)
+            try:
+                _verify(label, factory, is_reply, d)
+            except Exception as e:  # legitimately-N/A or codec gap
+                enc[label][d] = None
+                dec[label][d] = None
+                skips.append(f"{label} d{d}: {e}")
+                continue
+            enc[label][d] = _time_ns(_enc_fn(factory, prof),
+                                     args.duration, args.warmup)
+            dec[label][d] = _time_ns(_dec_fn(factory, d),
+                                     args.duration, args.warmup)
+
+    _print_table("ENCODE (serialize)", enc)
+    _print_table("DECODE (deserialize)", dec)
+
+    enc18, enc14 = _ratios(enc)
+    dec18, dec14 = _ratios(dec)
+    print("SUMMARY  (relative to d16, mean of per-message ratios)")
+    print(f"  encode   d18/d16 {enc18:5.2f}x   d14/d16 {enc14:5.2f}x")
+    print(f"  decode   d18/d16 {dec18:5.2f}x   d14/d16 {dec14:5.2f}x")
+    enc18_pct = (enc18 - 1.0) * 100.0
+    dec18_pct = (dec18 - 1.0) * 100.0
+    net = ((enc18 + dec18) / 2.0 - 1.0) * 100.0
+    print(f"  -> d18 control encode {enc18_pct:+.0f}% / decode {dec18_pct:+.0f}% "
+          f"vs d16; vi64 bodies + delta KVP + uint8 params net {net:+.0f}%.")
+
+    if skips:
+        print("\nskipped (message,draft) combos:")
+        for s in skips:
+            print(f"  - {s}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/relays.json
+++ b/tests/relays.json
@@ -16,9 +16,10 @@
         "raw-quic": "moqt://moqx-main.ci.openmoq.org:4433",
         "h3-wt":    "https://moqx-main.ci.openmoq.org:4433/moq-relay"
       },
-      "drafts": [14, 16],
+      "drafts": [14, 16, 18],
       "pub_mode": "publish",
-      "disabled_suites": []
+      "disabled_suites": [],
+      "notes": "openmoq CI moxygen relay. d18 staged ahead of the deploy that will offer it — until that lands the d18 columns fail at handshake (moqt-18 ALPN not yet advertised: QUIC error 376 / TLS no_application_protocol). d14/d16 are green over both raw-QUIC and H3/WT (/moq-relay)."
     },
     {
       "name": "cloudflare-d14",


### PR DESCRIPTION
Developer tooling + docs for 0.10.4 (no protocol/runtime changes).

## Cross-draft microbenchmarks (d14/d16/d18)

- **`b8_control_roundtrip` (new)** — encode+decode round-trip of SUBSCRIBE / SUBSCRIBE_OK / PUBLISH / PUBLISH_OK / REQUEST_UPDATE at all three drafts, with ENCODE/DECODE tables and a relative-to-d16 summary. Each (message, draft) combo is round-trip-verified (key fields asserted) before timing.
- **`b7_framer --draft all`** — cross-draft TX-framing comparison (subgroup-header / next-object / full-emit / batched-emit). Also **fixes a latent bug**: `--draft` was silently ignored — the probes always built an RFC9000 `SubgroupHeader`; they now thread `profile_for(draft)` so each draft encodes its own wire form (verified: d18 vi64 vs d14/d16 RFC9000).
- **`b1_parser --draft all`** — RX-parse comparison; the corpus (`_bytestream.py`) was d16-only and is now draft-parametrized. Single-`--draft N` behavior preserved on both.

All three print a comparative table + a relative summary computed from the measured numbers.

### Measured result
d16→d18 is **parity** (within ~2%) across control round-trip, TX framing, and RX parse. The real cost step is **d14→d16** (when fixed fields moved into delta-coded KVP params), which predates the d18 work — i.e. the vi64/d18 refactor added ~no per-draft cost.

## Docs
README **"Developing against a locally built aiopquic"** — host-tuned source build vs the portable PyPI wheel, the editable-first install order for a separate-venv-per-repo workflow, and how to verify the local build is actually in use (`aiopquic.__file__` / `python -m aiomoqt.versions`).

Full suite: **268 passed**.