### PR TITLE
tests: tidy moqx-main relay note

### DIFF
--- a/tests/relays.json
+++ b/tests/relays.json
@@ -19,7 +19,7 @@
       "drafts": [14, 16, 18],
       "pub_mode": "publish",
       "disabled_suites": [],
-      "notes": "openmoq CI moxygen relay. d18 staged ahead of the deploy that will offer it — until that lands the d18 columns fail at handshake (moqt-18 ALPN not yet advertised: QUIC error 376 / TLS no_application_protocol). d14/d16 are green over both raw-QUIC and H3/WT (/moq-relay)."
+      "notes": "openmoq moqx CI relay. Covers drafts 14/16/18 over both raw-QUIC and H3/WT (/moq-relay)."
     },
     {
       "name": "cloudflare-d14",


### PR DESCRIPTION
Reword the `moqx-main` entry note in `tests/relays.json`.

- Fix the name: it's the **moqx** relay (openmoq/moqx repo), not "moxygen".
- Drop the transient d18-staging / handshake-error verbiage that no longer holds once the deploy advertises moqt-18.
- State what's configured: drafts 14/16/18 over both raw-QUIC and H3/WT (/moq-relay).

Docs/metadata only — no runtime or test-logic change.