### PR TITLE
0.10.5: README accuracy + cleanup pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.10.5 (unreleased)
 
+- **Requires aiopquic >= 0.3.10** (was >= 0.3.9). The paired aiopquic release;
+  no new aiopquic API is used — the floor moves so the pair installs together.
 - **Retired the `MOQT_CUR_VERSION` module constant** (closes #4 follow-up). It
   was a fixed alias for `MOQT_VERSION_DRAFT14` left over from the pre-0.10.0
   module-global version context; the four remaining read sites now reference the
@@ -16,6 +18,13 @@
   0.10.2) and updated the interop / example tables to draft-14/16/18. Trimmed
   verbose prose, reflowed needless hard wraps, and collapsed `\`-continued shell
   commands.
+- **CLI help-text accuracy.** `--draft` help in six example tools listed only
+  "14, 16" → now "14, 16, or 18"; `sub_bench -t/--duration` help said
+  "default: 30" but the default is 0 (run until the publisher closes);
+  `relay_probe`'s module docstring described the retired two-probe design → now
+  one probe per draft over the URL's transport. README example table gained the
+  missing `moq_interop_relay.py` row, and a note that `-h` is `--host` (help is
+  `-?`/`--help`).
 
 ## v0.10.4 (2026-06-26)
 
@@ -416,7 +425,7 @@ divergence reads a `DraftProfile` capability flag.
   is removed (use `draft_version=[...]`); session `_moqt_version` renamed
   `_draft`.
 
-## v0.9.12 (unreleased)
+## v0.9.12 (2026-06-21)
 
 ### SUBSCRIBE: omit default-valued params (conformant "conservative sender")
 
@@ -467,7 +476,7 @@ Pairs with aiopquic 0.3.8 (no aiopquic change). Bug-fix release.
 
 - The integration tier (which PR + main CI run) now includes `loopback_bench` smokes across **draft-14 / draft-16 × raw-QUIC / WebTransport** and an `adaptive_bench --mp-loopback` (multi-process BW pub+sub) smoke per draft. This guards our own tools against the regression classes that slipped through 0.9.7–0.9.9: session-setup / ALPN breaks (caught by the loopback_bench matrix) and the multi-process publisher/subscriber start path (caught by `--mp-loopback`, which the in-process loopback never exercised). No external relay required.
 
-## v0.9.9 (unreleased)
+## v0.9.9 (2026-06-17)
 
 Pairs with aiopquic 0.3.8 (no aiopquic change). Targeted follow-up to
 v0.9.8 fixing bench-tool regressions; examples only, no core library
@@ -493,7 +502,7 @@ change.
 
 - `relay-join` / `relay-fetch` no longer skipped wholesale: the suites run on every reachable relay so results are honest — pass where supported, fail where not — instead of hidden behind `disabled_suites`. Verified passing on moqx / moxygen / imquic (d14+d16) and cloudflare-d14 (join); the rest report real fails/timeouts.
 
-## v0.9.8 (unreleased)
+## v0.9.8 (2026-06-14)
 
 Pairs with aiopquic 0.3.8; dep floor `aiopquic>=0.3.7` → `aiopquic>=0.3.8`
 (needs 0.3.8's real-negotiated-ALPN reporting).
@@ -589,7 +598,7 @@ ring-rename catch-up).
 
 - Saturation-stress edge cases on the producer-side stream lifecycle (see aiopquic 0.3.6 Known Issues — pub-stream orphan at saturation, shutdown drain miss, `-P 8 -g 200` double-free). Sub-saturation workloads are clean; these manifest only at sustained max-rate.
 
-## v0.9.5 (unreleased)
+## v0.9.5 (2026-05-26)
 
 Pairs with [aiopquic 0.3.5](https://pypi.org/project/aiopquic/0.3.5/);
 dep floor `aiopquic>=0.3.2` → `aiopquic>=0.3.5`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
   objects* failed its SUBSCRIBE with "Request timed out" and the control stream
   desynced; only the first subscriber (empty track, no largest) worked. Surfaced
   by the moqx-main d18 interop regression; covered by a new wire-layout test.
+- **Interop relay adapter honors draft confinement.** `moq_interop_relay` now
+  reads the draft from `$DRAFT` (moq-interop-runner PR #95) / `$MOQT_DRAFT`,
+  exactly like the client: a single draft confines the relay to it; when neither
+  is set (the open-relay context) it advertises all of 14/16/18 so any client
+  negotiates. Previously the relay only took `--draft` (default 16) and ignored
+  the runner's env, so a client pinned to draft-14 could not negotiate against
+  the relay (it kept offering 16/18). The docker entrypoint no longer threads
+  `--draft` (both roles read the env themselves). Works unchanged against the
+  current public runner.
 - **Requires aiopquic >= 0.3.10** (was >= 0.3.9). The paired aiopquic release;
   no new aiopquic API is used — the floor moves so the pair installs together.
 - **Retired the `MOQT_CUR_VERSION` module constant** (closes #4 follow-up). It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## v0.10.5 (unreleased)
 
+- **Fixed draft-18 `LARGEST_OBJECT` (Location) parameter codec.** At draft-18 the
+  `LARGEST_OBJECT` (0x09) parameter value is an inline Location — group + object
+  varints with no length prefix — not the d16 length-prefixed form. SubscribeOk
+  and Publish now encode/decode it inline (new `location_params` column on
+  `DraftProfile`). Previously the generic odd-type rule read the group as a length
+  and overran the buffer, so a subscriber joining a track that *already had
+  objects* failed its SUBSCRIBE with "Request timed out" and the control stream
+  desynced; only the first subscriber (empty track, no largest) worked. Surfaced
+  by the moqx-main d18 interop regression; covered by a new wire-layout test.
 - **Requires aiopquic >= 0.3.10** (was >= 0.3.9). The paired aiopquic release;
   no new aiopquic API is used — the floor moves so the pair installs together.
 - **Retired the `MOQT_CUR_VERSION` module constant** (closes #4 follow-up). It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v0.10.5 (unreleased)
 
+- **Retired the `MOQT_CUR_VERSION` module constant** (closes #4 follow-up). It
+  was a fixed alias for `MOQT_VERSION_DRAFT14` left over from the pre-0.10.0
+  module-global version context; the four remaining read sites now reference the
+  draft-14 constant directly, so nothing implies a mutable "current" version.
+  Per-session version state is unchanged (`self._profile` / `negotiated_draft`).
 - **README accuracy + cleanup pass.** Fixed the Quick Start examples that passed
   the removed `draft_version=` kwarg (now `supported_drafts=`). Refreshed the
   relay-probe Quick Start with current output (draft-14/16/18 over raw QUIC and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## v0.10.4 (unreleased)
+## v0.10.5 (unreleased)
+
+- **README accuracy + cleanup pass.** Fixed the Quick Start examples that passed
+  the removed `draft_version=` kwarg (now `supported_drafts=`). Refreshed the
+  relay-probe Quick Start with current output (draft-14/16/18 over raw QUIC and
+  H3/WT) and corrected the Relay Probe reference: dropped the removed
+  `--once`/`PROBE_ONCE`, fixed the `--interval` default (`0` = probe once), added
+  `--draft`. Removed the stale "d18 FETCH is pending" limitation (shipped in
+  0.10.2) and updated the interop / example tables to draft-14/16/18. Trimmed
+  verbose prose, reflowed needless hard wraps, and collapsed `\`-continued shell
+  commands.
+
+## v0.10.4 (2026-06-26)
 
 - **Cross-draft (d14/d16/d18) microbenchmarks.** New `b8_control_roundtrip`
   times encode+decode of SUBSCRIBE / SUBSCRIBE_OK / PUBLISH / PUBLISH_OK /
@@ -28,7 +40,7 @@
   version`, `connection refused - H3/WT not supported`); the raw error +
   handshake WARNING/ERROR logs appear only under `--debug`.
 
-## v0.10.3 (unreleased)
+## v0.10.3 (2026-06-23)
 
 - **draft-18 pub-sub object delivery fixed (REQUEST_UPDATE wire format).**
   draft-18 removed the `Existing Request ID` field from `REQUEST_UPDATE`
@@ -44,7 +56,7 @@
   corners (d16/d18 × raw-QUIC / WebTransport): 3/3 subscribers, objects
   delivered. d14/d16 pub-sub is unchanged.
 
-## v0.10.2 (unreleased)
+## v0.10.2 (2026-06-23)
 
 - **draft-18 FETCH / joining-FETCH / FETCH_OK now use the request stream.**
   `fetch()`, the joining-fetch helper, and `fetch_ok()` were sending on the
@@ -62,7 +74,7 @@
   publish at the `forward=1` trigger before streaming objects, so subscribers
   receive 0 objects. Tracked for 0.10.3. d14/d16 pub-sub is unaffected.
 
-## v0.10.1 (unreleased)
+## v0.10.1 (2026-06-22)
 
 - **Preference-ordered draft probe (interop client).** A single
   `moq_interop_client` invocation now probes its `supported_drafts` in
@@ -88,7 +100,7 @@
   `--compat` still adds to whatever the endpoint contributes. Default-off for
   all other hosts (no global leniency).
 
-## v0.10.0 (unreleased)
+## v0.10.0 (2026-06-21)
 
 **draft-18 support (beta).** aiomoqt now speaks draft-18 alongside d14/d16,
 over both raw QUIC and WebTransport, built on a version-dispatch refactor

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,11 +1,6 @@
 # aiomoqt Performance & Benchmarks
 
-How to benchmark the stack, what governs latency and throughput, and
-point-in-time observed numbers. All figures here are **observations on
-specific hardware under specific conditions, not absolute capabilities**
-— kernel UDP loopback rates, CPU, and scheduler behavior move them
-substantially between platforms. Calibrate on your own hardware with
-the commands below.
+How to benchmark the stack, what governs latency and throughput, and point-in-time observed numbers. All figures are **observations on specific hardware, not absolute capabilities** (UDP loopback rate, CPU, and scheduler move them substantially) — calibrate on your own with the commands below.
 
 The transport-layer view (TX/RX dataflow, flow control, configuration
 parameters) lives in

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Both venvs must use the **same Python version**. C/Cython changes need a rebuild
 
 ## Known Limitations
 
-- **draft-18 is beta.** Negotiated by default (`(18, 16, 14)`, newest-first) over raw QUIC and WebTransport, with control, FETCH, and SUBGROUP object delivery validated end to end. Not yet complete: SUBSCRIBE / PUBLISH subscription-filter and largest-location still use the d16 nested form; Track-Properties extensions encode as RFC9000 varints (correct for the small values in use). draft-14 / draft-16 are unaffected and remain the stable path.
+- **draft-18 is beta.** Negotiated by default (`(18, 16, 14)`, newest-first) over raw QUIC and WebTransport, with control, FETCH, and SUBGROUP object delivery validated end to end (including subscribers that join a track which already has objects). Not yet complete: the SUBSCRIBE / PUBLISH subscription-filter still uses the d16 nested form; Track-Properties extensions encode as RFC9000 varints (correct for the small values in use). draft-14 / draft-16 are unaffected and remain the stable path.
 - **WebTransport fetch / join routing** -- four `[wt]` test variants of FETCH and JOINING_SUBSCRIBE return empty results when the underlying transport is WebTransport. Raw-QUIC variants of the same tests pass and cover the MoQT-level invariant. Tracked separately; affects WT-only consumers of fetch/join.
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ python -m aiomoqt.examples.server_example --certificate cert.pem --private-key k
 | `server_example.py` | WebTransport server (origin) |
 | `relay_probe.py` | Relay version probe (draft-14/16/18) |
 | `moq_interop_client.py` | Interop test client (TAP v14 out; 6 standard + `fetch`/`join`) |
+| `moq_interop_relay.py` | Minimal interop relay (control plane; experimental) |
 
 ## Interop
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ python -m aiomoqt.examples.sub_example -h relay.ex.com -q
 python -m aiomoqt.examples.join_example -h relay.ex.com -q
 ```
 
-Common options: `--namespace`, `--trackname`, `--path`, `--debug`, `--keylogfile`. Every tool prints its full option set with `-?` / `--help`.
+Common options: `--namespace`, `--trackname`, `--path`, `--debug`, `--keylogfile`. Every tool prints its full option set with `-?` / `--help` (note: `-h` is `--host`, not help).
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Features
 
 - H3/WebTransport and raw QUIC transports
-- Draft-14 / draft-16 / draft-18 negotiation (ALPN `moq-00` / `moqt-16`; d18 via ALPN / WT-Protocol)
+- Draft-14 / draft-16 / draft-18 negotiation (ALPN `moq-00` / `moqt-16` / `moqt-18`, plus WT-Protocol over H3)
 - Draft-16 wire format: delta-encoded param keys, track extensions, unified request/response
 - Draft-18 (beta): vi64 varints, uni-stream control pair, per-request bidi streams, Request-ID-less replies — over both raw QUIC and WebTransport
 - SubgroupHeader / ObjectDatagram flag encoding, delta-encoded object IDs
@@ -65,10 +65,10 @@ python -m aiomoqt.versions   # or: aiomoqt-versions
 # Liveness + supported drafts against a single relay (one line per probed transport).
 # Exit 0 if the relay answered SERVER_SETUP for at least one draft.
 python -m aiomoqt.examples.relay_probe --url moqt://moqx-main.ci.openmoq.org:4433
-# → moqx-main.ci.openmoq.org:4433  quic   draft-14,draft-16  ✓ (405ms)
+# → moqt://moqx-main.ci.openmoq.org:4433              QUIC   ✓  draft-14,draft-16,draft-18  (540ms)
 
 python -m aiomoqt.examples.relay_probe --url https://moqx-main.ci.openmoq.org:4433/moq-relay
-# → moqx-main.ci.openmoq.org:4433  h3/wt  draft-14,draft-16  ✓ (315ms)
+# → https://moqx-main.ci.openmoq.org:4433/moq-relay   H3/WT  ✓  draft-14,draft-16,draft-18  (435ms)
 ```
 
 ### Subscriber
@@ -82,7 +82,7 @@ def on_object(msg, size, recv_time_ms, group_id=None, subgroup_id=None):
 
 async def main():
     client = MOQTClient('relay.example.com', 443, path='moq',
-                         use_quic=True, draft_version=16)
+                         use_quic=True, supported_drafts=16)
     async with client.connect() as session:
         await session.client_session_init()
         session.on_object_received = on_object
@@ -102,7 +102,7 @@ from aiomoqt.messages import SubgroupHeader
 
 async def main():
     client = MOQTClient('relay.example.com', 443, path='moq',
-                         use_quic=True, draft_version=16)
+                         use_quic=True, supported_drafts=16)
     client.register_handler(MOQTMessageType.SUBSCRIBE, on_subscribe)
     async with client.connect() as session:
         await session.client_session_init()
@@ -188,22 +188,17 @@ python -m aiomoqt.examples.moq_interop_client -l
 
 ### Relay Probe
 
-Batch liveness + draft-version check. Reads a relay list, does a
-real CLIENT_SETUP / SERVER_SETUP handshake per (endpoint × draft) —
-no bare-ALPN tricks — and writes a JSON status report.
-
-Accepts CLI flags, environment variables, or both (CLI overrides env):
+Batch liveness + draft-version check: reads a relay list, does a real CLIENT_SETUP / SERVER_SETUP handshake per (endpoint × draft), and writes a JSON status report. Accepts CLI flags, environment variables, or both (CLI overrides env). A single endpoint can also be probed inline with `--url` (see Quick Start above).
 
 ```bash
-# CLI form (typical interactive use)
-python -m aiomoqt.examples.relay_probe -f relays.json -o status.json --once
-
-# Env form (typical container/daemon deployment)
-RELAYS_FILE=relays.json OUTPUT_FILE=status.json PROBE_ONCE=1 \
-  python -m aiomoqt.examples.relay_probe
-
-# Long-running monitor (re-probe every --interval seconds)
+# Probe a relay list once and write a status report (CLI form)
 python -m aiomoqt.examples.relay_probe -f relays.json -o status.json
+
+# Same, env form (typical container/daemon deployment)
+RELAYS_FILE=relays.json OUTPUT_FILE=status.json python -m aiomoqt.examples.relay_probe
+
+# Long-running monitor: re-probe every 300s
+python -m aiomoqt.examples.relay_probe -f relays.json -o status.json --interval 300
 ```
 
 | CLI flag | Env var | Default | Meaning |
@@ -211,14 +206,13 @@ python -m aiomoqt.examples.relay_probe -f relays.json -o status.json
 | `-f / --relays-file` | `RELAYS_FILE` | `/app/relays.json` | input relay list |
 | `-o / --output-file` | `OUTPUT_FILE` | `/output/relay-status.json` | status report destination |
 | `--timeout` | `PROBE_TIMEOUT` | `8` | per-probe handshake timeout (s) |
-| `--interval` | `PROBE_INTERVAL` | `300` | re-probe cadence in monitor mode (s) |
-| `--once` | `PROBE_ONCE=1` | unset | probe once and exit |
+| `--interval` | `PROBE_INTERVAL` | `0` | re-probe cadence (s); `0` probes once and exits |
+| `--draft` | — | all | draft(s) to probe: `--draft 18` or `--draft 18,16` (add `--offer` to offer the list in one session) |
 
 ### WebTransport Server
 
 ```bash
-python -m aiomoqt.examples.server_example \
-    --certificate cert.pem --private-key key.pem --port 443
+python -m aiomoqt.examples.server_example --certificate cert.pem --private-key key.pem --port 443
 ```
 
 ### Example Reference
@@ -235,32 +229,16 @@ python -m aiomoqt.examples.server_example \
 | `loopback_bench.py` | Local loopback (no relay) |
 | `adaptive_bench.py` | Ramps rate until buffer growth; loopback (`--mp-loopback` for proc-isolated pub/sub) or relay |
 | `server_example.py` | WebTransport server (origin) |
-| `relay_probe.py` | Relay version probe (draft-14/16) |
+| `relay_probe.py` | Relay version probe (draft-14/16/18) |
 | `moq_interop_client.py` | Interop test client (TAP v14 out; 6 standard + `fetch`/`join`) |
 
 ## Interop
 
-Validated against live public relays — OpenMoQ moqx, Meta moxygen,
-Cloudflare moq-rs, Quicr libquicr, Meetecho imquic, OzU moqtail —
-across draft-14/draft-16 and both transports, using the
-[moq-interop-runner](https://github.com/englishm/moq-interop-runner)
-cases plus a multi-subscriber pub-sub bench. The full point-in-time
-matrix lives in [PERFORMANCE.md](PERFORMANCE.md#interop-matrix-point-in-time);
-the relay catalog with per-endpoint notes is
-[`tests/relays.json`](tests/relays.json). Red5 Pro was interop-tested
-in earlier cycles and is currently untested/unverified.
+Validated against live public relays — OpenMoQ moqx, Meta moxygen, Cloudflare moq-rs, Quicr libquicr, Meetecho imquic, OzU moqtail, Nokia — across draft-14/draft-16/draft-18 and both transports, using the [moq-interop-runner](https://github.com/englishm/moq-interop-runner) cases plus a multi-subscriber pub-sub bench. The full point-in-time matrix lives in [PERFORMANCE.md](PERFORMANCE.md#interop-matrix-point-in-time); the relay catalog with per-endpoint notes is [`tests/relays.json`](tests/relays.json). Red5 Pro was interop-tested in earlier cycles and is currently untested/unverified.
 
 ## Performance
 
-`aiomoqt` sits on [`aiopquic`](https://github.com/gmarzot/aiopquic),
-which sits on picoquic + the kernel UDP path; throughput at this layer
-is bounded by the layers below. Observed on commodity hardware over
-loopback: multi-Gbps sustained throughput at ~4 KiB objects with
-bounded memory under stream churn, and sub-millisecond to
-low-millisecond latency when paced below saturation. Numbers vary
-substantially by platform — methodology, observed figures, the
-paced-vs-unpaced distinction, and TX budget tuning are in
-[PERFORMANCE.md](PERFORMANCE.md).
+`aiomoqt` sits on [`aiopquic`](https://github.com/gmarzot/aiopquic), which sits on picoquic + the kernel UDP path; throughput at this layer is bounded by the layers below. Observed on commodity hardware over loopback: multi-Gbps sustained throughput at ~4 KiB objects with bounded memory under stream churn, and sub-millisecond to low-millisecond latency when paced below saturation. Numbers vary substantially by platform — methodology, observed figures, the paced-vs-unpaced distinction, and TX budget tuning are in [PERFORMANCE.md](PERFORMANCE.md).
 
 ## Development
 
@@ -270,60 +248,42 @@ cd aiomoqt
 python3 -m venv .venv && source .venv/bin/activate
 uv pip install -e ".[test]"    # or: pip install -e ".[test]"
 
-# Self-signed cert for the loopback server (loopback_bench, pub_server,
-# and the test_loopback_* suites; skipped if certs/ is absent). One time:
-mkdir -p certs && openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
-  -keyout certs/key.pem -out certs/cert.pem -subj "/CN=localhost" \
-  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+# One-time self-signed cert for the loopback server + test_loopback_* suites (skipped if certs/ is absent)
+mkdir -p certs && openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -keyout certs/key.pem -out certs/cert.pem -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
 pytest aiomoqt/tests/
 ```
 
 ### Developing against a locally built aiopquic
 
-The PyPI `aiopquic` wheel is built **portable** (runs on any CPU of the
-architecture). A locally compiled `aiopquic` is **host-tuned** (`-O3
--march=native -flto`, plus picotls Fusion AES-GCM on x86_64) and is
-measurably faster in many cases — build it from source when benchmarking or
-optimizing, and on bare-metal targets generally.
+The PyPI `aiopquic` wheel is **portable** (any CPU of the architecture). A locally compiled `aiopquic` is **host-tuned** (`-O3 -march=native -flto`, plus picotls Fusion AES-GCM on x86_64) and is measurably faster — build from source when benchmarking, optimizing, or targeting bare metal.
 
 ```bash
-# build aiopquic from source (host-tuned by default)
+# Build aiopquic from source (host-tuned by default; AIOPQUIC_WHEEL_BUILD=1 for a portable build)
 git clone https://github.com/gmarzot/aiopquic.git
-cd aiopquic
-git submodule update --init --recursive
-./build_picoquic.sh          # -march/-mcpu=native -flto; AIOPQUIC_WHEEL_BUILD=1 for a portable build
+cd aiopquic && git submodule update --init --recursive && ./build_picoquic.sh
 ```
 
-`aiomoqt`'s venv must then have **this editable aiopquic** installed —
-otherwise `uv pip install -e` pulls the portable wheel from PyPI. In a single
-shared venv, install both editable. With a **separate venv per repo** (e.g. two
-shells), install the local aiopquic into the aiomoqt venv **first**, so the
-dependency is already satisfied and no wheel is fetched:
+With a **separate venv per repo**, install the local aiopquic into the aiomoqt venv **first**, so the dependency is already satisfied and no wheel is fetched (re-run it any time the wheel sneaks back in — it replaces the wheel install):
 
 ```bash
 # in the aiomoqt venv:
-uv pip install -e ~/aiopquic     # local source, editable — BEFORE aiomoqt
-uv pip install -e '.[test]'      # aiopquic dep already satisfied → no wheel
+uv pip install -e ~/aiopquic    # local source, editable — BEFORE aiomoqt
+uv pip install -e '.[test]'     # aiopquic already satisfied → no wheel
 ```
 
-If aiomoqt already grabbed the wheel, just re-run `uv pip install -e ~/aiopquic`
-— it replaces the wheel install. Confirm the local build is actually in use
-(this catches the wheel sneaking back in):
+Confirm the local build is actually in use:
 
 ```bash
 python -c "import aiopquic; print(aiopquic.__file__)"   # must be <repo>/src/aiopquic/…, not …/site-packages/
-python -m aiomoqt.versions                              # aiopquic path + picoquic/picotls SHAs match your build
+python -m aiomoqt.versions                              # paths + picoquic/picotls SHAs match your build
 ```
 
-Both venvs must use the **same Python version** — the editable build's compiled
-extension lives in the aiopquic source tree and is shared across venvs that
-point at it. C/Cython changes need a rebuild (`./build_picoquic.sh` if the C
-libs changed, then `uv pip install -e ~/aiopquic`); pure-Python edits are live.
+Both venvs must use the **same Python version**. C/Cython changes need a rebuild (`./build_picoquic.sh` then `uv pip install -e ~/aiopquic`); pure-Python edits are live.
 
 ## Known Limitations
 
-- **draft-18 is beta.** Negotiated by default (`(18, 16, 14)`, newest-first) over raw QUIC and WebTransport, with control + SUBGROUP object delivery validated end to end. Not yet complete: SUBSCRIBE / PUBLISH subscription-filter and largest-location still use the d16 nested form; d18 FETCH is pending; Track-Properties extensions encode as RFC9000 varints (correct for the small values in use). draft-14 / draft-16 are unaffected and remain the stable path.
+- **draft-18 is beta.** Negotiated by default (`(18, 16, 14)`, newest-first) over raw QUIC and WebTransport, with control, FETCH, and SUBGROUP object delivery validated end to end. Not yet complete: SUBSCRIBE / PUBLISH subscription-filter and largest-location still use the d16 nested form; Track-Properties extensions encode as RFC9000 varints (correct for the small values in use). draft-14 / draft-16 are unaffected and remain the stable path.
 - **WebTransport fetch / join routing** -- four `[wt]` test variants of FETCH and JOINING_SUBSCRIBE return empty results when the underlying transport is WebTransport. Raw-QUIC variants of the same tests pass and cover the MoQT-level invariant. Tracked separately; affects WT-only consumers of fetch/join.
 
 ## TODO
@@ -338,8 +298,7 @@ libs changed, then `uv pip install -e ~/aiopquic`); pure-Python edits are live.
 
 ## Contributing
 
-Contributions are welcome! Please fork the repository, create a branch,
-and submit a pull request. For major changes, open an issue first.
+Contributions are welcome! Please fork the repository, create a branch, and submit a pull request. For major changes, open an issue first.
 
 ## Resources
 
@@ -356,6 +315,4 @@ Giovanni Marzot — [gmarzot@marzresearch.net](mailto:gmarzot@marzresearch.net) 
 
 ## Acknowledgements
 
-This project takes inspiration from, and has benefited from the great work
-done by the [OpenMoQ/moxygen](https://github.com/openmoq/moxygen) team,
-and the continued efforts of the MOQ IETF WG.
+This project takes inspiration from, and has benefited from the great work done by the [OpenMoQ/moxygen](https://github.com/openmoq/moxygen) team, and the continued efforts of the MOQ IETF WG.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,13 @@
 
 ## Installation
 
-Pure Python, requires Python 3.12+ (tested on 3.12, 3.13, 3.14):
+Pure Python, requires Python 3.12+ (tested on 3.12, 3.13, 3.14). For a clean, uv-managed `.venv`, run `./bootstrap_python.sh`; otherwise install into your current environment:
 
 ```bash
 uv pip install aiomoqt    # or: pip install aiomoqt
 ```
 
 `aiopquic` (the QUIC transport) installs as a binary wheel automatically. Only Linux (glibc 2.34+, RHEL 9 / Ubuntu 22.04+) and macOS arm64 have prebuilt wheels; other systems pull `aiopquic` via sdist and need a C build toolchain — see [aiopquic install notes](https://github.com/gmarzot/aiopquic#installation).
-
-A `./bootstrap_python.sh` script is provided for a uv-managed `.venv` if you want a clean dev environment.
 
 ### Reporting issues
 
@@ -56,19 +54,16 @@ aiopquic:  0.3.7.dev12+g6eef9caf6 (~/src/aiopquic/src/aiopquic) [2026-06-11 11:5
 
 ### Verify install + relay liveness
 
-Confirm the stack is wired up before writing any code:
+Confirm the stack and reach a relay before writing any code (probe exits 0 if any draft handshakes):
 
 ```bash
-# Versions of aiomoqt + aiopquic + picoquic + picotls
-python -m aiomoqt.versions   # or: aiomoqt-versions
+python -m aiomoqt.versions
 
-# Liveness + supported drafts against a single relay (one line per probed transport).
-# Exit 0 if the relay answered SERVER_SETUP for at least one draft.
 python -m aiomoqt.examples.relay_probe --url moqt://moqx-main.ci.openmoq.org:4433
-# → moqt://moqx-main.ci.openmoq.org:4433              QUIC   ✓  draft-14,draft-16,draft-18  (540ms)
+moqt://moqx-main.ci.openmoq.org:4433              QUIC   ✓  draft-14,draft-16,draft-18  (540ms)
 
 python -m aiomoqt.examples.relay_probe --url https://moqx-main.ci.openmoq.org:4433/moq-relay
-# → https://moqx-main.ci.openmoq.org:4433/moq-relay   H3/WT  ✓  draft-14,draft-16,draft-18  (435ms)
+https://moqx-main.ci.openmoq.org:4433/moq-relay   H3/WT  ✓  draft-14,draft-16,draft-18  (435ms)
 ```
 
 ### Subscriber

--- a/aiomoqt/context.py
+++ b/aiomoqt/context.py
@@ -44,6 +44,11 @@ class DraftProfile:
                                   # uint8 (not a varint): d18 FORWARD 0x10 /
                                   # SUBSCRIBER_PRIORITY 0x20 / GROUP_ORDER
                                   # 0x22. Empty for d14/d16.
+    location_params: frozenset = frozenset()
+                                  # params whose VALUE is an inline Location
+                                  # (group + object varints, no length prefix):
+                                  # d18 LARGEST_OBJECT 0x09. Empty for d14/d16
+                                  # (there LARGEST_OBJECT is length-prefixed).
 
     @property
     def vi64(self) -> bool:
@@ -75,7 +80,8 @@ PROFILES = {
             ParamType.FORWARD,
             ParamType.SUBSCRIBER_PRIORITY,
             ParamType.GROUP_ORDER,
-        })),
+        }),
+        location_params=frozenset({ParamType.LARGEST_OBJECT})),
 }
 
 

--- a/aiomoqt/examples/adaptive_bench.py
+++ b/aiomoqt/examples/adaptive_bench.py
@@ -1490,7 +1490,7 @@ def parse_args():
     p.add_argument("--interval", type=float, default=5.0,
                    metavar="S", help="controller tick period seconds (default: 5)")
     p.add_argument("--draft", type=parse_draft_spec, default=None,
-                   help="MoQT draft version (14 or 16)")
+                   help="MoQT draft version: 14, 16, or 18")
     p.add_argument("-n", "--namespace", default="aiomoqt",
                    help="MoQT namespace (default: aiomoqt)")
     p.add_argument("--trackname", default=None,

--- a/aiomoqt/examples/loopback_bench.py
+++ b/aiomoqt/examples/loopback_bench.py
@@ -79,7 +79,7 @@ def parse_args():
         help='Use raw QUIC instead of WebTransport (default: WT)')
     parser.add_argument(
         '-D', '--draft', type=parse_draft_spec, default=14,
-        help='MoQT draft version to negotiate (e.g. 14 or 16, '
+        help='MoQT draft version to negotiate (e.g. 14, 16, or 18, '
              'default: 14). Applied to BOTH the loopback publisher '
              '(server) and subscriber (client) so the raw-QUIC ALPN '
              '("moq-00" for d14, "moqt-NN" for d16+) and the WT version '

--- a/aiomoqt/examples/moq_interop_relay.py
+++ b/aiomoqt/examples/moq_interop_relay.py
@@ -57,6 +57,14 @@ from aiomoqt.messages.request import RequestError
 from aiomoqt.context import is_draft16_or_later
 from aiomoqt.utils.logger import set_log_level, get_logger
 
+# Version confinement. The interop runner injects DRAFT (moq-interop-runner
+# PR #95) — or older MOQT_DRAFT — to pin the relay to one draft; the client
+# is pinned the same way, so negotiation lands on that draft. When neither is
+# set (the open-relay context, where clients offer their full version list),
+# advertise every supported draft so any client negotiates.
+_RELAY_DRAFT_DEFAULT = (os.environ.get("DRAFT")
+                        or os.environ.get("MOQT_DRAFT") or "14,16,18").strip()
+
 logger = get_logger(__name__)
 
 
@@ -179,8 +187,11 @@ def parse_args():
                              "(shares the namespace table) — lets one "
                              "instance back both remote-webtransport "
                              "(--port) and remote-quic (--quic-port)")
-    parser.add_argument("--draft", type=parse_draft_spec, default=16,
-                        help="MoQT draft version (default: 16)")
+    parser.add_argument("--draft", type=parse_draft_spec,
+                        default=parse_draft_spec(_RELAY_DRAFT_DEFAULT),
+                        help="MoQT draft(s) to serve: a single draft confines "
+                             "negotiation to it; a list offers all of them. "
+                             "Default from $DRAFT / $MOQT_DRAFT, else 14,16,18.")
     parser.add_argument("--debug", action="store_true",
                         help="Enable debug logging")
     return parser.parse_args()

--- a/aiomoqt/examples/pub_bench.py
+++ b/aiomoqt/examples/pub_bench.py
@@ -107,7 +107,7 @@ examples:
     parser.add_argument('-k', '--insecure', action='store_true',
                         help='Skip TLS certificate verification')
     parser.add_argument('--draft', type=parse_draft_spec, default=None,
-                        help='MoQT draft version (e.g. 14, 16)')
+                        help='MoQT draft version: 14, 16, or 18')
     parser.add_argument('--cc-algo', type=str, default=None,
                         help='Congestion control algorithm '
                              '(bbr | bbr1 | newreno | cubic | dcubic | '

--- a/aiomoqt/examples/pub_example.py
+++ b/aiomoqt/examples/pub_example.py
@@ -243,7 +243,7 @@ def parse_args():
     parser.add_argument('--keylogfile', type=str, default=None, help='TLS secrets file')
     parser.add_argument('--insecure', action='store_true', help='Skip TLS certificate verification')
     parser.add_argument('--auth-token', type=str, default=None, help='Auth token')
-    parser.add_argument('--draft', type=parse_draft_spec, default=None, help='MoQT draft version (e.g. 14, 16)')
+    parser.add_argument('--draft', type=parse_draft_spec, default=None, help='MoQT draft version: 14, 16, or 18')
     parser.add_argument('-P', '--streams', type=int, default=1, help='Parallel subgroup streams (default: 1)')
     parser.add_argument('-s', '--object-size', type=int, default=1024, help='Object payload size bytes (default: 1024)')
     parser.add_argument('-r', '--rate', type=float, default=30, help='Frames per second (default: 30)')

--- a/aiomoqt/examples/relay_probe.py
+++ b/aiomoqt/examples/relay_probe.py
@@ -2,9 +2,10 @@
 """
 MOQ relay probe — determines relay liveness and supported draft versions.
 
-Each endpoint URL gets exactly 2 probes:
-  - moqt:// URLs: raw QUIC with moqt-16 ALPN, then moq-00 ALPN
-  - https:// URLs: H3/WebTransport with moqt-16, then moq-00
+Each endpoint URL is probed once per draft (14, 16, 18 by default; use
+--draft to narrow), over the transport its scheme selects:
+  - moqt:// URLs: raw QUIC (moqt-NN / moq-00 ALPN)
+  - https:// URLs: H3/WebTransport (WT-Protocol)
 
 Each probe does a proper CLIENT_SETUP/SERVER_SETUP handshake and clean close.
 No bare ALPN probes, no custom protocol classes, no half-open connections.

--- a/aiomoqt/examples/sub_bench.py
+++ b/aiomoqt/examples/sub_bench.py
@@ -365,7 +365,7 @@ examples:
              '(required by some relays)')
     parser.add_argument(
         '-t', '--duration', type=int, default=0,
-        help='Duration in seconds (default: 30)')
+        help='Duration in seconds; 0 = run until the publisher closes (default: 0)')
     parser.add_argument(
         '-i', '--interval', type=float, default=5.0,
         help='Report interval in seconds (default: 5)')
@@ -378,7 +378,7 @@ examples:
         help='Skip TLS certificate verification')
     parser.add_argument(
         '--draft', type=parse_draft_spec, default=None,
-        help='MoQT draft version (e.g. 14, 16)')
+        help='MoQT draft version: 14, 16, or 18')
     parser.add_argument(
         '--cc-algo', type=str, default=None,
         help='Congestion control algorithm '

--- a/aiomoqt/examples/sub_example.py
+++ b/aiomoqt/examples/sub_example.py
@@ -27,7 +27,7 @@ def parse_args():
     parser.add_argument('--keylogfile', type=str, default=None, help='TLS secrets file')
     parser.add_argument('--insecure', action='store_true', help='Skip TLS certificate verification')
     parser.add_argument('--auth-token', type=str, default=None, help='Auth token')
-    parser.add_argument('--draft', type=parse_draft_spec, default=None, help='MoQT draft version (e.g. 14, 16)')
+    parser.add_argument('--draft', type=parse_draft_spec, default=None, help='MoQT draft version: 14, 16, or 18')
     parser.add_argument('--libquicr-compat', action='store_true', help='Use libquicr filter encoding (LAPS)')
     parser.add_argument('-t', '--duration', type=int, default=120, help='Duration in seconds (default: 120)')
     parser.add_argument('--subscribe-options', type=int, default=None,

--- a/aiomoqt/messages/base.py
+++ b/aiomoqt/messages/base.py
@@ -403,7 +403,14 @@ class MOQTMessage:
             else:
                 payload.push_vint(param_type)  # Type
 
-            if param_type % 2 == 1:  # Odd type - includes Length field
+            if param_type in prof.location_params:
+                # Inline Location value: group + object varints, no length
+                # prefix (d18 LARGEST_OBJECT 0x09). Value is a (group, object)
+                # tuple.
+                loc_group, loc_object = param_value
+                payload.push_vint(loc_group)
+                payload.push_vint(loc_object)
+            elif param_type % 2 == 1:  # Odd type - includes Length field
                 # Value is bytes or string
                 if isinstance(param_value, str):
                     param_value = param_value.encode()
@@ -471,7 +478,14 @@ class MOQTMessage:
             else:
                 param_type = raw_key
 
-            if param_type % 2 == 1:  # Odd type - includes Length field
+            if param_type in prof.location_params:
+                # Inline Location value: group + object varints, no length
+                # prefix (d18 LARGEST_OBJECT 0x09). Read both regardless of
+                # the odd/even rule; stored as a (group, object) tuple.
+                loc_group = buf.pull_vint()
+                loc_object = buf.pull_vint()
+                param_value = (loc_group, loc_object)
+            elif param_type % 2 == 1:  # Odd type - includes Length field
                 param_len = buf.pull_vint()
                 if param_len > 65535:  # 2^16-1 maximum
                     raise MOQTProtocolViolation(

--- a/aiomoqt/messages/publish.py
+++ b/aiomoqt/messages/publish.py
@@ -59,10 +59,16 @@ class Publish(MOQTMessage):
             if self.forward is not None:
                 params[ParamType.FORWARD] = self.forward
             if self.largest_group_id is not None:
-                lbuf = Buffer(capacity=16)
-                lbuf.push_uint_var(self.largest_group_id)
-                lbuf.push_uint_var(self.largest_object_id or 0)
-                params[ParamType.LARGEST_OBJECT] = lbuf.data_slice(0, lbuf.tell())
+                if ParamType.LARGEST_OBJECT in prof.location_params:
+                    # d18: inline Location value — (group, object) tuple
+                    params[ParamType.LARGEST_OBJECT] = (
+                        self.largest_group_id, self.largest_object_id or 0)
+                else:
+                    # d16: length-prefixed bytes(group varint + object varint)
+                    lbuf = Buffer(capacity=16)
+                    lbuf.push_uint_var(self.largest_group_id)
+                    lbuf.push_uint_var(self.largest_object_id or 0)
+                    params[ParamType.LARGEST_OBJECT] = lbuf.data_slice(0, lbuf.tell())
             MOQTMessage._serialize_params(payload, params, prof=prof)
             # Track Extensions
             exts = dict(self.track_extensions or {})
@@ -108,11 +114,16 @@ class Publish(MOQTMessage):
         if is_draft16_or_later(prof.draft):
             params = MOQTMessage._deserialize_params(buf, prof=prof, buf_end=buf_end)
             forward = params.pop(ParamType.FORWARD, None)
-            largest_raw = params.pop(ParamType.LARGEST_OBJECT, None)
-            if largest_raw is not None:
-                lbuf = Buffer(data=largest_raw)
-                largest_group_id = lbuf.pull_vint()
-                largest_object_id = lbuf.pull_vint()
+            largest = params.pop(ParamType.LARGEST_OBJECT, None)
+            if largest is not None:
+                if isinstance(largest, tuple):
+                    # d18: inline Location value (group, object)
+                    largest_group_id, largest_object_id = largest
+                else:
+                    # d16: length-prefixed bytes(group varint + object varint)
+                    lbuf = Buffer(data=largest)
+                    largest_group_id = lbuf.pull_vint()
+                    largest_object_id = lbuf.pull_vint()
                 content_exists = ContentExistsCode.EXISTS
             else:
                 content_exists = ContentExistsCode.NO_CONTENT

--- a/aiomoqt/messages/subscribe.py
+++ b/aiomoqt/messages/subscribe.py
@@ -436,11 +436,18 @@ class SubscribeOk(MOQTMessage):
             if self.expires is not None:
                 params[ParamType.EXPIRES] = self.expires
             if self.largest_group_id is not None:
-                # LARGEST_OBJECT param (0x09, odd) = bytes(group_id varint + object_id varint)
-                lbuf = Buffer(capacity=16)
-                lbuf.push_uint_var(self.largest_group_id)
-                lbuf.push_uint_var(self.largest_object_id or 0)
-                params[ParamType.LARGEST_OBJECT] = lbuf.data_slice(0, lbuf.tell())
+                if ParamType.LARGEST_OBJECT in prof.location_params:
+                    # d18: LARGEST_OBJECT is an inline Location value —
+                    # (group, object) tuple, encoded as two bare varints.
+                    params[ParamType.LARGEST_OBJECT] = (
+                        self.largest_group_id, self.largest_object_id or 0)
+                else:
+                    # d16: LARGEST_OBJECT (0x09, odd) = length-prefixed
+                    # bytes(group_id varint + object_id varint)
+                    lbuf = Buffer(capacity=16)
+                    lbuf.push_uint_var(self.largest_group_id)
+                    lbuf.push_uint_var(self.largest_object_id or 0)
+                    params[ParamType.LARGEST_OBJECT] = lbuf.data_slice(0, lbuf.tell())
             MOQTMessage._serialize_params(payload, params, prof=prof)
             # Track Extensions (group_order goes here as extension 0x22)
             exts = dict(self.track_extensions or {})
@@ -482,11 +489,16 @@ class SubscribeOk(MOQTMessage):
         if is_draft16_or_later(prof.draft):
             params = MOQTMessage._deserialize_params(buf, prof=prof, buf_end=buf_end)
             expires = params.pop(ParamType.EXPIRES, None)
-            largest_raw = params.pop(ParamType.LARGEST_OBJECT, None)
-            if largest_raw is not None:
-                lbuf = Buffer(data=largest_raw)
-                largest_group_id = lbuf.pull_vint()
-                largest_object_id = lbuf.pull_vint()
+            largest = params.pop(ParamType.LARGEST_OBJECT, None)
+            if largest is not None:
+                if isinstance(largest, tuple):
+                    # d18: inline Location value (group, object)
+                    largest_group_id, largest_object_id = largest
+                else:
+                    # d16: length-prefixed bytes(group varint + object varint)
+                    lbuf = Buffer(data=largest)
+                    largest_group_id = lbuf.pull_vint()
+                    largest_object_id = lbuf.pull_vint()
                 content_exists = ContentExistsCode.EXISTS
             else:
                 content_exists = ContentExistsCode.NO_CONTENT

--- a/aiomoqt/protocol.py
+++ b/aiomoqt/protocol.py
@@ -174,7 +174,7 @@ class _MOQTSessionMixin:
         drift; assigning it resolves _profile. The wire IETF version code
         is materialized only when (de)serializing SETUP / building ALPN."""
         prof = getattr(self, '_profile', None)
-        return prof.draft if prof is not None else get_major_version(MOQT_CUR_VERSION)
+        return prof.draft if prof is not None else get_major_version(MOQT_VERSION_DRAFT14)
 
     @negotiated_draft.setter
     def negotiated_draft(self, value: int) -> None:
@@ -211,7 +211,7 @@ class _MOQTSessionMixin:
         _drafts = getattr(session, 'supported_drafts', None)
         _pinned = _drafts[0] if _drafts and len(_drafts) == 1 else None
         self.negotiated_draft = (get_major_version(_pinned) if _pinned is not None
-                                 else get_major_version(MOQT_CUR_VERSION))
+                                 else get_major_version(MOQT_VERSION_DRAFT14))
         self._moqt_session_setup: Future[bool] = self._loop.create_future()
         self._moqt_session_closed: Future[Tuple[int,str]] = self._loop.create_future()
         self._next_request_id = 0 if self._is_client else 1
@@ -1747,7 +1747,7 @@ class _MOQTSessionMixin:
 
     def server_setup(
         self,
-        selected_version: int = MOQT_CUR_VERSION,
+        selected_version: int = MOQT_VERSION_DRAFT14,
         parameters: Optional[Dict[int, bytes]] = None
     ) -> ServerSetup:
         """Send SERVER_SETUP message in response to CLIENT_SETUP."""
@@ -2347,7 +2347,7 @@ class _MOQTSessionMixin:
             # (the wire format omits it). Trust the ALPN-resolved version
             # already set in self.negotiated_draft on ProtocolNegotiated.
             version_ok = (
-                is_draft16_or_later(self.negotiated_draft) or MOQT_CUR_VERSION in msg.versions
+                is_draft16_or_later(self.negotiated_draft) or MOQT_VERSION_DRAFT14 in msg.versions
             )
             if version_ok:
                 self.server_setup()

--- a/aiomoqt/tests/test_messages.py
+++ b/aiomoqt/tests/test_messages.py
@@ -1165,6 +1165,36 @@ class TestDraft18ControlMessages:
             skip_fields={'request_id', 'content_exists', 'track_extensions'},
         )
 
+    def test_subscribe_ok_d18_largest_is_inline_location(self):
+        # d18 LARGEST_OBJECT (0x09) is a Location value: group + object
+        # varints written INLINE with NO length prefix (moxygen
+        # paramEncodingV18). Guards the regression where the generic
+        # odd-type rule read the group as a length and overran the buffer
+        # for subscribers joining a track that already has objects.
+        from aiomoqt.context import profile_for
+        prof = profile_for(18)
+        msg = SubscribeOk(
+            request_id=0, track_alias=42, group_order=GroupOrder.ASCENDING,
+            content_exists=ContentExistsCode.EXISTS,
+            largest_group_id=5, largest_object_id=200)
+        raw = bytes(msg.serialize(prof=prof).data)
+        hdr = Buffer(data=raw, vi64=prof.vi64)
+        hdr.pull_vint()                 # message Type
+        hdr.pull_uint16()               # message Length
+        body = raw[hdr.tell():]
+        w = Buffer(data=body, vi64=prof.vi64)
+        assert w.pull_vint() == 42      # track_alias (no request_id on d18 wire)
+        assert w.pull_vint() == 1       # param count
+        assert w.pull_vint() == 0x09    # LARGEST_OBJECT key (delta from 0)
+        # INLINE Location: the next bytes are the group and object varints,
+        # NOT a length prefix. A length-prefixed encoding would read 0x?? here.
+        assert w.pull_vint() == 5       # group
+        assert w.pull_vint() == 200     # object
+        rt = SubscribeOk.deserialize(Buffer(data=body, vi64=prof.vi64),
+                                     prof=prof, buf_end=len(body))
+        assert (rt.largest_group_id, rt.largest_object_id) == (5, 200)
+        assert rt.content_exists == ContentExistsCode.EXISTS
+
     # ---- PUBLISH (request) / PUBLISH_OK (reply) ----
     def test_publish_d18(self):
         assert moqt_message_serialization_versioned(
@@ -1176,6 +1206,28 @@ class TestDraft18ControlMessages:
                 'track_alias': 42,
                 'group_order': GroupOrder.ASCENDING,
                 'content_exists': ContentExistsCode.NO_CONTENT,
+                'forward': ForwardingPreference.SUBGROUP,
+                'parameters': {},
+                'track_extensions': {},
+            },
+            type_id=MOQTMessageType.PUBLISH,
+            version=self.D18,
+            skip_fields={'content_exists', 'track_extensions'},
+        )
+
+    def test_publish_d18_with_content(self):
+        # d18 Publish carrying a largest Location (inline group+object varints).
+        assert moqt_message_serialization_versioned(
+            Publish,
+            {
+                'request_id': 2,
+                'track_namespace': (b'vod',),
+                'track_name': b'movie1',
+                'track_alias': 99,
+                'group_order': GroupOrder.ASCENDING,
+                'content_exists': ContentExistsCode.EXISTS,
+                'largest_group_id': 50,
+                'largest_object_id': 200,
                 'forward': ForwardingPreference.SUBGROUP,
                 'parameters': {},
                 'track_extensions': {},

--- a/aiomoqt/types.py
+++ b/aiomoqt/types.py
@@ -11,7 +11,6 @@ MOQT_VERSIONS = [
     MOQT_VERSION_DRAFT14,
     MOQT_VERSION_DRAFT16,
 ]
-MOQT_CUR_VERSION = MOQT_VERSION_DRAFT14  # default; set per-session
 
 
 class MOQTDraft(IntEnum):

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,12 @@
 # moq-interop-runner entrypoint. Default role is the client; set
 # MOQT_ROLE=relay (matching the runner's docker-compose env) to start
 # the minimal interop relay on UDP/${MOQT_PORT:-4443}.
+#
+# Draft confinement is read from the environment by BOTH roles: the runner
+# injects DRAFT (PR #95) — or older MOQT_DRAFT — and the client and relay
+# each pin to it. Unset = open-relay context: the client offers its full
+# version list and the relay advertises all supported drafts. So no --draft
+# is threaded here; the programs read $DRAFT / $MOQT_DRAFT themselves.
 set -eu
 
 case "${MOQT_ROLE:-client}" in
@@ -12,7 +18,6 @@ case "${MOQT_ROLE:-client}" in
             --cert "${MOQT_CERT:-/certs/cert.pem}" \
             --key  "${MOQT_KEY:-/certs/priv.key}" \
             ${MOQT_QUIC:+--quic} \
-            ${MOQT_DRAFT:+--draft "$MOQT_DRAFT"} \
             "$@"
         ;;
     client|*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "certifi",
-    "aiopquic>=0.3.9",
+    "aiopquic>=0.3.10",
     "sortedcontainers>=2.4.0",
 ]
 

--- a/tests/release_regression_test.py
+++ b/tests/release_regression_test.py
@@ -33,7 +33,13 @@ import subprocess
 import sys
 import tempfile
 import threading
+import uuid
 from pathlib import Path
+
+# Unique per regression run. Track names embed this so every published track is
+# distinct across runs AND transports — strict relays (e.g. moqx) reject/mishandle
+# a name republished with different content, so we never reuse one.
+_RUN_ID = uuid.uuid4().hex[:8]
 
 _PRINT_LOCK = threading.Lock()
 
@@ -472,7 +478,7 @@ def _run_relay_matrix(relay: dict, enabled: set[str],
                 _dispatch("relay-ctrl-msg", "", tag, slug,
                           _relay_ctrl_msg, url, draft, insecure, compat_csv)
             if "relay-pub-sub" in enabled:
-                tn = f"rr-{rname}-{draft}"
+                tn = f"rr-{rname}-{transport}-{draft}-{_RUN_ID}"
                 _dispatch("relay-pub-sub", f"[{pub_mode}]", tag, slug,
                           lambda u, d, log: _relay_pub_sub(
                               u, d, pub_mode, insecure, compat_csv,


### PR DESCRIPTION
Opening the **0.10.5** cycle. Starts with a README correctness + cleanup pass; **kept open** for further cleanup/fixes before tagging (0.10.4 is the version in use now).

## README
- **Fixed broken Quick Start examples** — Subscriber and Publisher passed `draft_version=16`, a kwarg that no longer exists (`MOQTClient` takes `supported_drafts=`). As written the snippets crashed. Verified all example symbols/kwargs resolve against the current API.
- **Refreshed the relay-probe Quick Start** with verified live output (uppercase `QUIC`/`H3/WT`, ✓ before drafts, draft-14/16/18 green over both transports).
- **Corrected the Relay Probe reference** — removed the deleted `--once`/`PROBE_ONCE`, fixed `--interval` default (`300`→`0` = probe once), added a `--draft` row.
- **Fixed stale facts** — dropped "d18 FETCH is pending" (shipped in 0.10.2); interop + example tables now say draft-14/16/18.
- **Style** — collapsed `\`-continued shell commands (server_example, openssl, env-form probe), trimmed the verbose locally-built-aiopquic section, reflowed the hard-wrapped Interop/Performance/Contributing/Acknowledgements prose.

## CHANGELOG
- Added `v0.10.5 (unreleased)`.
- Datestamped the released `0.10.0`–`0.10.4` entries (were stale `(unreleased)`). Older `0.9.x (unreleased)` leftovers left as a separate cleanup.

Docs-only — no runtime or test change.